### PR TITLE
ci: fix cache dependency

### DIFF
--- a/.github/workflows/check-maintainers.yml
+++ b/.github/workflows/check-maintainers.yml
@@ -15,6 +15,8 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
+        with:
+          cache-dependency-glob: ci/check-maintainers
 
       - name: Check Maintainers
         run: ci/check-maintainers ./maintainers.yml

--- a/.github/workflows/sync-maintainers.yml
+++ b/.github/workflows/sync-maintainers.yml
@@ -20,6 +20,8 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
+        with:
+          cache-dependency-glob: ci/sync-maintainers
 
       - name: Install git crypt
         run: sudo apt-get update && sudo apt-get install -y git-crypt


### PR DESCRIPTION
Hopefully this will fix the warning we have been getting, and make caching work.

```
No file matched to [/home/runner/work/challenges/challenges/**/*requirements*.txt,/home/runner/work/challenges/challenges/**/*requirements*.in,/home/runner/work/challenges/challenges/**/*constraints*.txt,/home/runner/work/challenges/challenges/**/*constraints*.in,/home/runner/work/challenges/challenges/**/pyproject.toml,/home/runner/work/challenges/challenges/**/uv.lock,/home/runner/work/challenges/challenges/**/*.py.lock]. The cache will never get invalidated. Make sure you have checked out the target repository and configured the cache-dependency-glob input correctly.
```
