### PR TITLE
ci: refactor list-changed-challenges

### DIFF
--- a/ci/list-changed-challenges
+++ b/ci/list-changed-challenges
@@ -1,170 +1,188 @@
-#!/bin/bash
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.9"
+# ///
 
-# Script to detect changed challenges in a git repository
-# Usage: ./list-changed-challenges [BASE_SHA] [HEAD_SHA]
-#        ./list-changed-challenges [BASE_SHA]  # compares BASE_SHA with HEAD
-#
-# If no arguments provided, it will try to detect from GitHub Actions environment
-# Output: Space-separated list of changed challenge paths (module/challenge format)
-#
-# This script also detects when common templates change and includes all challenges
-# that depend on those templates
+"""
+Script to detect changed challenges in a git repository.
 
-set -e
+Usage:
+  ./ci/list-changed-challenges [BASE_SHA] [HEAD_SHA]
+  ./ci/list-changed-challenges [BASE_SHA]  # compares BASE_SHA with HEAD
 
-# Determine the SHAs to compare
-if [ $# -eq 2 ]; then
-    # Use provided arguments
-    BASE_SHA="$1"
-    HEAD_SHA="$2"
-elif [ $# -eq 1 ]; then
-    # Single argument is the BASE SHA, compare with current HEAD
-    BASE_SHA="$1"
-    HEAD_SHA="HEAD"
-elif [ -n "$GITHUB_EVENT_NAME" ]; then
-    # Running in GitHub Actions
-    if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
-        BASE_SHA="${GITHUB_BASE_SHA:-$GITHUB_EVENT_PULL_REQUEST_BASE_SHA}"
-        HEAD_SHA="HEAD"
-    else
-        # For pushes, use the before and after commits from the push event
-        BASE_SHA="${GITHUB_EVENT_BEFORE}"
-        HEAD_SHA="${GITHUB_EVENT_AFTER}"
+If no arguments are provided, the script derives the comparison range from the
+GitHub Actions environment or defaults to comparing with main. Output is a
+newline-separated list of changed challenge paths (module/challenge format).
 
-        # If this is the first commit or force push with no common history
-        if [ "$BASE_SHA" = "0000000000000000000000000000000000000000" ]; then
-            # Compare against empty tree
-            BASE_SHA=$(git hash-object -t tree /dev/null)
-        fi
-    fi
-else
-    # Default to comparing with main branch
-    # Check if we're on main branch locally
-    CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
-    if [ "$CURRENT_BRANCH" = "main" ]; then
-        # On main branch, compare with origin/main
-        if git rev-parse --verify origin/main >/dev/null 2>&1; then
-            BASE_SHA="origin/main"
-        else
-            echo "Error: On main branch but origin/main not found" >&2
-            exit 1
-        fi
-    else
-        # Not on main, compare with local main
-        if git rev-parse --verify main >/dev/null 2>&1; then
-            BASE_SHA="main"
-        else
-            echo "Error: Could not find main branch" >&2
-            exit 1
-        fi
-    fi
-    HEAD_SHA="HEAD"
-fi
+Changes under any `common/` directory bubble down to every challenge beneath it.
+"""
 
-# Find all challenges that use (extend/include) a template
-find_dependent_challenges() {
-    local template="$1"
-    template=${template#./}
-    local name=$(basename "$template")
-    local rel_path=${template#challenges/}
-    rel_path=${rel_path#*/}  # Remove module prefix
+from __future__ import annotations
 
-    # Find all .j2 files in challenge dirs that reference this template
-    find challenges -name "*.j2" -path "*/challenge/*" 2>/dev/null | \
-        xargs grep -lE "{%-? *(extends|include).*[\"'](.*/)?(${name}|${rel_path})[\"']" 2>/dev/null | \
-        sed 's|^challenges/||' | sed -E 's#/challenge/.*##' | sort -u || true
-}
+import os
+import pathlib
+import subprocess
+import sys
+from typing import Dict, Iterable, List, Sequence, Set
 
-# Recursively find all templates that depend on a given template
-find_child_templates() {
-    local template="$1"
-    template=${template#./}
-    local module_path=${template#challenges/}
-    local module=${module_path%%/*}
-    local module_dir="challenges/$module"
-    local seen=()
-    local queue=("$template")
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+CHALLENGES_DIR = REPO_ROOT / "challenges"
+CHALLENGES_PREFIX = pathlib.PurePosixPath("challenges")
 
-    while [ ${#queue[@]} -gt 0 ]; do
-        local current="${queue[0]}"
-        queue=("${queue[@]:1}")  # Remove first element
-
-        # Skip if already seen
-        [[ " ${seen[@]} " =~ " ${current} " ]] && continue
-        seen+=("$current")
-
-        local name=$(basename "$current")
-        local rel_path=${current#challenges/}
-        rel_path=${rel_path#*/}
-
-        # Find templates that reference this one
-        local children=$(
-            grep -rE "{%-? *(extends|include).*[\"'](.*/)?(${name}|${rel_path})[\"']" \
-                --include="*.j2" "$module_dir" 2>/dev/null | cut -d':' -f1 | sort -u || true
-        )
-
-        # Add children to queue
-        for child in $children; do
-            [[ " ${seen[@]} " =~ " ${child} " ]] || queue+=("$child")
-        done
-    done
-
-    printf '%s\n' "${seen[@]}"
-}
-
-has_challenge_dir() {
-    local dir="$1"
-    [ -d "$dir/challenge" ]
-}
-
-find_challenge_root() {
-    local path="$1"
-    while [[ "$path" == challenges/* ]]; do
-        if has_challenge_dir "$path"; then
-            echo "${path#challenges/}"
-            return 0
-        fi
-        local parent
-        parent=$(dirname "$path")
-        if [ "$parent" = "$path" ]; then
-            break
-        fi
-        path="$parent"
-    done
-    return 1
-}
-
-DIRECT_CHALLENGES=$(
-    git diff --name-only "$BASE_SHA" "$HEAD_SHA" | \
-    while IFS= read -r path; do
-        [[ -z "$path" ]] && continue
-        [[ "$path" != challenges/* ]] && continue
-        dir=$(dirname "$path")
-        if challenge=$(find_challenge_root "$dir"); then
-            printf '%s\n' "$challenge"
-        fi
-    done | sort -u || true
+EMPTY_TREE_SHA = "0000000000000000000000000000000000000000"
+USAGE = (
+    "Usage: ./ci/list-changed-challenges [BASE_SHA] [HEAD_SHA]\n"
+    "       ./ci/list-changed-challenges [BASE_SHA]\n"
+    "\n"
+    "If no arguments are provided, the script compares the current branch "
+    "against main (or uses GitHub Actions metadata when available)."
 )
-CHANGED_COMMON_TEMPLATES=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA" | grep -E '^challenges/.*/common/.*\.j2$' || true)
 
-declare -A AFFECTED_CHALLENGES_SET
 
-# Add directly changed challenges that exist
-for challenge in $DIRECT_CHALLENGES; do
-    if [[ -d "challenges/$challenge/challenge" || -d "challenges/$challenge/tests_public" || -d "challenges/$challenge/tests_private" ]]; then
-        AFFECTED_CHALLENGES_SET["$challenge"]=1
-    fi
-done
+def run_git_command(*args: str) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=REPO_ROOT,
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    return result.stdout.strip()
 
-# Process common template changes
-for template in $CHANGED_COMMON_TEMPLATES; do
-    # Find all templates that depend on this one (including itself)
-    for dependent_template in $(find_child_templates "$template"); do
-        # Find all challenges using this template
-        for challenge in $(find_dependent_challenges "$dependent_template"); do
-            AFFECTED_CHALLENGES_SET["$challenge"]=1
-        done
-    done
-done
 
-[ ${#AFFECTED_CHALLENGES_SET[@]} -eq 0 ] || printf '%s\n' "${!AFFECTED_CHALLENGES_SET[@]}" | sort
+def ensure_ref_exists(ref: str) -> None:
+    try:
+        run_git_command("rev-parse", "--verify", ref)
+    except subprocess.CalledProcessError as exc:
+        raise RuntimeError(f"Git reference {ref!r} not found") from exc
+
+
+def determine_commit_range(args: Sequence[str]) -> tuple[str, str]:
+    if len(args) > 2:
+        raise RuntimeError(USAGE)
+    if len(args) == 2:
+        return args[0], args[1]
+    if len(args) == 1:
+        return args[0], "HEAD"
+
+    event_name = os.environ.get("GITHUB_EVENT_NAME")
+    if event_name:
+        if event_name == "pull_request":
+            base = os.environ.get("GITHUB_BASE_SHA") or os.environ.get(
+                "GITHUB_EVENT_PULL_REQUEST_BASE_SHA"
+            )
+            if not base:
+                raise RuntimeError("Could not determine BASE_SHA for pull_request event")
+            return base, "HEAD"
+        base = os.environ.get("GITHUB_EVENT_BEFORE")
+        head = os.environ.get("GITHUB_EVENT_AFTER")
+        if not base or not head:
+            raise RuntimeError("Push event missing GITHUB_EVENT_BEFORE/AFTER")
+        if base == EMPTY_TREE_SHA:
+            base = run_git_command("hash-object", "-t", "tree", "/dev/null")
+        return base, head
+
+    current_branch = run_git_command("rev-parse", "--abbrev-ref", "HEAD")
+    head = "HEAD"
+    if current_branch == "main":
+        ensure_ref_exists("origin/main")
+        return "origin/main", head
+    ensure_ref_exists("main")
+    return "main", head
+
+
+def list_changed_files(base: str, head: str) -> List[pathlib.PurePosixPath]:
+    output = run_git_command("diff", "--name-only", base, head)
+    return [
+        pathlib.PurePosixPath(line)
+        for line in output.splitlines()
+        if line.strip()
+    ]
+
+
+def discover_challenges(root: pathlib.Path) -> Dict[pathlib.PurePosixPath, str]:
+    if not root.is_dir():
+        raise RuntimeError(f"Challenges directory {root} not found")
+    challenges: Dict[pathlib.PurePosixPath, str] = {}
+    for dirpath, dirnames, _ in os.walk(root):
+        if "challenge" not in dirnames:
+            continue
+        candidate = pathlib.Path(dirpath)
+        relative = candidate.relative_to(root)
+        if relative == pathlib.Path("."):
+            continue
+        rel_posix = relative.as_posix()
+        challenge_root = CHALLENGES_PREFIX / rel_posix
+        challenges[challenge_root] = rel_posix
+    return challenges
+
+
+def find_challenge_for_path(
+    path: pathlib.PurePosixPath, challenges: Dict[pathlib.PurePosixPath, str]
+) -> str | None:
+    current = path
+    while True:
+        if current in challenges:
+            return challenges[current]
+        if current == CHALLENGES_PREFIX or len(current.parts) < 2:
+            return None
+        current = current.parent
+
+
+def collect_common_ancestors(
+    paths: Iterable[pathlib.PurePosixPath],
+) -> Set[pathlib.PurePosixPath]:
+    ancestors: Set[pathlib.PurePosixPath] = set()
+    for path in paths:
+        if not path.is_relative_to(CHALLENGES_PREFIX):
+            continue
+        parts = path.parts
+        try:
+            start_idx = parts.index("common", 1)
+        except ValueError:
+            continue
+        ancestors.add(pathlib.PurePosixPath(*parts[:start_idx]))
+    return ancestors
+
+
+def apply_common_changes(
+    challenges: Dict[pathlib.PurePosixPath, str],
+    ancestors: Set[pathlib.PurePosixPath],
+) -> Set[str]:
+    affected: Set[str] = set()
+    if not ancestors:
+        return affected
+    challenge_roots = list(challenges.keys())
+    for ancestor in ancestors:
+        for root in challenge_roots:
+            if root.is_relative_to(ancestor):
+                affected.add(challenges[root])
+    return affected
+
+
+def main(argv: Sequence[str]) -> int:
+    try:
+        base, head = determine_commit_range(argv[1:])
+        changed_paths = list_changed_files(base, head)
+        if not changed_paths:
+            return 0
+        challenges = discover_challenges(CHALLENGES_DIR)
+        affected: Set[str] = set()
+        for path in changed_paths:
+            if not path.is_relative_to(CHALLENGES_PREFIX):
+                continue
+            challenge = find_challenge_for_path(path, challenges)
+            if challenge:
+                affected.add(challenge)
+        affected.update(apply_common_changes(challenges, collect_common_ancestors(changed_paths)))
+        for challenge in sorted(affected):
+            print(challenge)
+        return 0
+    except RuntimeError as exception:
+        print(exception, file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))


### PR DESCRIPTION
The prior implementation is super slow. This PR uses our current definition that a challenge is simply a directory which immediately contains a directory named "challenge". If any files in a challenge directory (for example, including tests) change, the challenge has changed. We also walk all ancestors back up to the root challenges directory, looking for "common" directories. If any files inside one of these "common" directory changes, the challenge has changed.

This significantly improves performance, but will over-estimate on the "common" directories case (we no longer try to more intelligently analyze if the common-dependency is actually used).