### PR TITLE
ci: test challenges by group

### DIFF
--- a/.github/workflows/test-challenges.yml
+++ b/.github/workflows/test-challenges.yml
@@ -69,12 +69,6 @@ jobs:
 
         echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
 
-        {
-          echo "table<<'EOF'"
-          echo "$TABLE"
-          echo "EOF"
-        } >> "$GITHUB_OUTPUT"
-
   test-challenges:
     needs: detect-changes
     if: needs.detect-changes.outputs.has-changes == 'true'

--- a/.github/workflows/test-challenges.yml
+++ b/.github/workflows/test-challenges.yml
@@ -19,11 +19,11 @@ jobs:
   detect-changes:
     runs-on: ubuntu-latest
     outputs:
-      matrix: ${{ steps.set-matrix.outputs.matrix }}
-      has-changes: ${{ steps.set-matrix.outputs.has-changes }}
+      matrix: ${{ steps.changed-challenges.outputs.matrix }}
+      has-changes: ${{ steps.changed-challenges.outputs.has-changes }}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0  # Fetch all history for proper diff
 
@@ -35,118 +35,45 @@ jobs:
     - name: Get challenges to test
       id: changed-challenges
       run: |
+        set -euo pipefail
+
         if [ "${{ github.event_name }}" = "workflow_dispatch" ] || [ "${{ github.event_name }}" = "schedule" ]; then
-          echo "Testing all challenges (triggered by ${{ github.event_name }})"
-          CHALLENGES=$(./ci/list-challenges | tr '\n' ' ')
+          echo "Collecting all challenges (triggered by ${{ github.event_name }})"
+          TABLE=$(./ci/list-challenges)
+          MATRIX=$(./ci/list-challenges --format matrix)
         else
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            BASE="${{ github.event.pull_request.base.sha }}"
-            HEAD="${{ github.event.pull_request.head.sha }}"
+            REF="${{ github.event.pull_request.base.sha }}"
           else
-            BASE="${{ github.event.before }}"
-            HEAD="${{ github.event.after }}"
+            REF="${{ github.event.before }}"
           fi
 
-          CHALLENGES=$(./ci/list-challenges --only-modified "$BASE" "$HEAD" | tr '\n' ' ')
+          if [ -z "$REF" ] || [ "$REF" = "0000000000000000000000000000000000000000" ]; then
+            REF=$(git hash-object -t tree /dev/null)
+          fi
+
+          echo "Collecting challenges modified since $REF"
+          TABLE=$(./ci/list-challenges --modified-since "$REF")
+          MATRIX=$(./ci/list-challenges --modified-since "$REF" --format matrix)
         fi
 
-        echo "Challenges to test: $CHALLENGES"
-        echo "challenges=$CHALLENGES" >> $GITHUB_OUTPUT
+        echo "Challenges to test:"
+        echo "$TABLE"
 
-    - name: Set up matrix
-      id: set-matrix
-      env:
-        CHALLENGES: ${{ steps.changed-challenges.outputs.challenges }}
-      run: |
-        python <<'PY'
-        import fnmatch
-        import json
-        import os
-        import pathlib
-        import shlex
+        if [ "$MATRIX" = '{"group":[],"include":[]}' ]; then
+          echo "No challenges to test"
+          echo "has-changes=false" >> "$GITHUB_OUTPUT"
+        else
+          echo "has-changes=true" >> "$GITHUB_OUTPUT"
+        fi
 
-        repo_root = pathlib.Path(".").resolve()
-        challenges_root = repo_root / "challenges"
-        changed = [item for item in os.environ.get("CHALLENGES", "").split() if item]
-        output_path = pathlib.Path(os.environ["GITHUB_OUTPUT"])
+        echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
 
-        if not changed:
-            with output_path.open("a", encoding="utf-8") as handle:
-                handle.write("has-changes=false\n")
-                handle.write('matrix={"group":[]}\n')
-            raise SystemExit
-
-        def parse_git_crypt_attr(attr_path: pathlib.Path):
-            entries = []
-            for line in attr_path.read_text(encoding="utf-8").splitlines():
-                stripped = line.strip()
-                if not stripped or stripped.startswith("#"):
-                    continue
-                parts = shlex.split(stripped)
-                if len(parts) < 2:
-                    continue
-                pattern, attrs = parts[0], parts[1:]
-                for token in attrs:
-                    if token.startswith("filter=git-crypt-"):
-                        value = token.split("=", 1)[1]
-                        entries.append((pattern, value[len("git-crypt-") :]))
-            return entries
-
-        def list_challenge_files(challenge_path: pathlib.Path):
-            files = [path for path in challenge_path.rglob("*") if path.is_file()]
-            if not files:
-                # Even if the directory is empty, treat the directory itself as a candidate
-                files.append(challenge_path)
-            return files
-
-        def find_group(challenge: str) -> str:
-            challenge_path = challenges_root / challenge
-            if not challenge_path.exists():
-                return "default"
-
-            files = list_challenge_files(challenge_path)
-
-            ancestors = []
-            current = challenge_path
-            while True:
-                ancestors.append(current)
-                if current == challenges_root or current.parent == current:
-                    break
-                current = current.parent
-
-            for ancestor in ancestors:
-                attr_file = ancestor / ".gitattributes"
-                if not attr_file.is_file():
-                    continue
-                for pattern, group in parse_git_crypt_attr(attr_file):
-                    for file_path in files:
-                        try:
-                            relative = file_path.relative_to(attr_file.parent).as_posix()
-                        except ValueError:
-                            continue
-                        if fnmatch.fnmatch(relative, pattern):
-                            return group
-            return "default"
-
-        grouped = {}
-        for challenge in changed:
-            grouped.setdefault(find_group(challenge), []).append(challenge)
-
-        matrix = {
-            "group": sorted(grouped),
-            "include": [
-                {
-                    "group": group,
-                    "challenges": "\n".join(sorted(set(grouped[group]))),
-                }
-                for group in sorted(grouped)
-            ],
-        }
-
-        with output_path.open("a", encoding="utf-8") as handle:
-            handle.write("has-changes=true\n")
-            handle.write(f"matrix={json.dumps(matrix, separators=(',', ':'))}\n")
-        PY
+        {
+          echo "table<<'EOF'"
+          echo "$TABLE"
+          echo "EOF"
+        } >> "$GITHUB_OUTPUT"
 
   test-challenges:
     needs: detect-changes
@@ -157,7 +84,7 @@ jobs:
       matrix: ${{ fromJson(needs.detect-changes.outputs.matrix) }}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Install uv
       uses: astral-sh/setup-uv@v7

--- a/.github/workflows/test-challenges.yml
+++ b/.github/workflows/test-challenges.yml
@@ -58,22 +58,73 @@ jobs:
 
     - name: Set up matrix
       id: set-matrix
+      env:
+        CHALLENGES: ${{ steps.changed-challenges.outputs.challenges }}
       run: |
-        CHALLENGES="${{ steps.changed-challenges.outputs.challenges }}"
+        python <<'PY'
+        import json
+        import os
+        import pathlib
+        import shlex
 
-        if [ -z "$CHALLENGES" ]; then
-          echo "No challenges to test"
-          echo "has-changes=false" >> $GITHUB_OUTPUT
-          echo 'matrix={"challenge":[]}' >> $GITHUB_OUTPUT
-        else
-          echo "has-changes=true" >> $GITHUB_OUTPUT
+        repo_root = pathlib.Path(".").resolve()
+        challenges_root = repo_root / "challenges"
+        changed = [item for item in os.environ.get("CHALLENGES", "").split() if item]
+        output_path = pathlib.Path(os.environ["GITHUB_OUTPUT"])
 
-          # Convert space-separated list to JSON array using jq (trim whitespace first)
-          MATRIX=$(echo "$CHALLENGES" | xargs | tr ' ' '\n' | jq -R . | jq -s '{challenge: .}' -c)
+        if not changed:
+            with output_path.open("a", encoding="utf-8") as handle:
+                handle.write("has-changes=false\n")
+                handle.write('matrix={"group":[]}\n')
+            raise SystemExit
 
-          echo "Matrix: $MATRIX"
-          echo "matrix=$MATRIX" >> $GITHUB_OUTPUT
-        fi
+        def group_for_module(module_dir: pathlib.Path) -> str:
+            attr_file = module_dir / ".gitattributes"
+            if not attr_file.is_file():
+                return "unencrypted"
+            for line in attr_file.read_text(encoding="utf-8").splitlines():
+                stripped = line.strip()
+                if not stripped or stripped.startswith("#"):
+                    continue
+                parts = shlex.split(stripped)
+                if len(parts) < 2:
+                    continue
+                for token in parts[1:]:
+                    if token.startswith("filter="):
+                        value = token.split("=", 1)[1]
+                        if value.startswith("git-crypt-"):
+                            return value[len("git-crypt-") :]
+                        return value
+            return "unencrypted"
+
+        module_groups = {}
+        for module_dir in challenges_root.iterdir():
+            if module_dir.is_dir():
+                module_groups[module_dir.name] = group_for_module(module_dir)
+
+        def resolve_group(challenge: str) -> str:
+            module = challenge.split("/", 1)[0]
+            return module_groups.get(module, "unencrypted")
+
+        grouped = {}
+        for challenge in changed:
+            grouped.setdefault(resolve_group(challenge), []).append(challenge)
+
+        matrix = {
+            "group": sorted(grouped),
+            "include": [
+                {
+                    "group": group,
+                    "challenges": "\n".join(sorted(set(grouped[group]))),
+                }
+                for group in sorted(grouped)
+            ],
+        }
+
+        with output_path.open("a", encoding="utf-8") as handle:
+            handle.write("has-changes=true\n")
+            handle.write(f"matrix={json.dumps(matrix, separators=(',', ':'))}\n")
+        PY
 
   test-challenges:
     needs: detect-changes
@@ -103,23 +154,36 @@ jobs:
         # Find and remove directories containing encrypted files using git-crypt status (these cannot be tested currently)
         git crypt status -e | sed -e "s/ *encrypted: //" | xargs dirname | xargs rm -rf
 
-    - name: Test challenge
+    - name: Test challenges in group
+      env:
+        GROUP_CHALLENGES: ${{ matrix.challenges }}
+        GROUP_NAME: ${{ matrix.group }}
       run: |
-        echo "================================================"
-        echo "Testing challenge: ${{ matrix.challenge }}"
-        echo "================================================"
-
-        # Run the test and transform FAILED lines on the fly
-        ./build "./challenges/${{ matrix.challenge }}" 2>&1 | sed "s|^FAILED: /tmp/[^/]*/|::error::TEST FAILED: ${{ matrix.challenge }}/|"
-
-        # Check exit status of build (not sed)
-        if [ ${PIPESTATUS[0]} -eq 0 ]; then
-          echo "================================================"
-          echo "✓ ${{ matrix.challenge }} passed"
-          echo "================================================"
-        else
-          echo "================================================"
-          echo "✗ ${{ matrix.challenge }} failed"
-          echo "================================================"
-          exit 1
+        if [ -z "$GROUP_CHALLENGES" ]; then
+          echo "No challenges queued for group: $GROUP_NAME"
+          exit 0
         fi
+
+        while IFS= read -r challenge; do
+          if [ -z "$challenge" ]; then
+            continue
+          fi
+
+          echo "================================================"
+          echo "Group: $GROUP_NAME"
+          echo "Testing challenge: $challenge"
+          echo "================================================"
+
+          ./build "./challenges/$challenge" 2>&1 | sed "s|^FAILED: /tmp/[^/]*/|::error::TEST FAILED: $challenge/|"
+
+          if [ ${PIPESTATUS[0]} -eq 0 ]; then
+            echo "================================================"
+            echo "✓ $challenge passed"
+            echo "================================================"
+          else
+            echo "================================================"
+            echo "✗ $challenge failed"
+            echo "================================================"
+            exit 1
+          fi
+        done <<< "$GROUP_CHALLENGES"

--- a/.github/workflows/test-challenges.yml
+++ b/.github/workflows/test-challenges.yml
@@ -50,10 +50,7 @@ jobs:
           CHALLENGES=$(./ci/list-challenges --only-modified "$BASE" "$HEAD" | tr '\n' ' ')
         fi
 
-        # Output for debugging
         echo "Challenges to test: $CHALLENGES"
-
-        # Save raw output
         echo "challenges=$CHALLENGES" >> $GITHUB_OUTPUT
 
     - name: Set up matrix
@@ -62,6 +59,7 @@ jobs:
         CHALLENGES: ${{ steps.changed-challenges.outputs.challenges }}
       run: |
         python <<'PY'
+        import fnmatch
         import json
         import os
         import pathlib
@@ -78,37 +76,61 @@ jobs:
                 handle.write('matrix={"group":[]}\n')
             raise SystemExit
 
-        def group_for_module(module_dir: pathlib.Path) -> str:
-            attr_file = module_dir / ".gitattributes"
-            if not attr_file.is_file():
-                return "unencrypted"
-            for line in attr_file.read_text(encoding="utf-8").splitlines():
+        def parse_git_crypt_attr(attr_path: pathlib.Path):
+            entries = []
+            for line in attr_path.read_text(encoding="utf-8").splitlines():
                 stripped = line.strip()
                 if not stripped or stripped.startswith("#"):
                     continue
                 parts = shlex.split(stripped)
                 if len(parts) < 2:
                     continue
-                for token in parts[1:]:
-                    if token.startswith("filter="):
+                pattern, attrs = parts[0], parts[1:]
+                for token in attrs:
+                    if token.startswith("filter=git-crypt-"):
                         value = token.split("=", 1)[1]
-                        if value.startswith("git-crypt-"):
-                            return value[len("git-crypt-") :]
-                        return value
-            return "unencrypted"
+                        entries.append((pattern, value[len("git-crypt-") :]))
+            return entries
 
-        module_groups = {}
-        for module_dir in challenges_root.iterdir():
-            if module_dir.is_dir():
-                module_groups[module_dir.name] = group_for_module(module_dir)
+        def list_challenge_files(challenge_path: pathlib.Path):
+            files = [path for path in challenge_path.rglob("*") if path.is_file()]
+            if not files:
+                # Even if the directory is empty, treat the directory itself as a candidate
+                files.append(challenge_path)
+            return files
 
-        def resolve_group(challenge: str) -> str:
-            module = challenge.split("/", 1)[0]
-            return module_groups.get(module, "unencrypted")
+        def find_group(challenge: str) -> str:
+            challenge_path = challenges_root / challenge
+            if not challenge_path.exists():
+                return "default"
+
+            files = list_challenge_files(challenge_path)
+
+            ancestors = []
+            current = challenge_path
+            while True:
+                ancestors.append(current)
+                if current == challenges_root or current.parent == current:
+                    break
+                current = current.parent
+
+            for ancestor in ancestors:
+                attr_file = ancestor / ".gitattributes"
+                if not attr_file.is_file():
+                    continue
+                for pattern, group in parse_git_crypt_attr(attr_file):
+                    for file_path in files:
+                        try:
+                            relative = file_path.relative_to(attr_file.parent).as_posix()
+                        except ValueError:
+                            continue
+                        if fnmatch.fnmatch(relative, pattern):
+                            return group
+            return "default"
 
         grouped = {}
         for challenge in changed:
-            grouped.setdefault(resolve_group(challenge), []).append(challenge)
+            grouped.setdefault(find_group(challenge), []).append(challenge)
 
         matrix = {
             "group": sorted(grouped),

--- a/ci/list-challenges
+++ b/ci/list-challenges
@@ -4,175 +4,136 @@
 # ///
 
 """
-List challenges in the repository.
+List challenges grouped by git-crypt key.
 
-By default, all challenges are printed. Use --only-modified to list only the
-challenges affected by changes between two commits or refs. When no refs are
-supplied, the script compares the current branch against its upstream (or falls
-back to main/origin/main).
+--modified-since <REF> limits results to challenges affected by changes versus REF (includes staged/unstaged files).
 """
 
 from __future__ import annotations
 
 import argparse
+import json
 import os
 import pathlib
+import shlex
 import subprocess
-import sys
-from typing import Dict, List, Sequence, Set, Tuple
 
-REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
-CHALLENGES_DIR = REPO_ROOT / "challenges"
-CHALLENGES_PREFIX = pathlib.PurePosixPath("challenges")
+repo_root = pathlib.Path(__file__).resolve().parent.parent
+challenges_dir = repo_root / "challenges"
+prefix = pathlib.PurePosixPath("challenges")
 
-EMPTY_TREE_SHA = "0000000000000000000000000000000000000000"
+parser = argparse.ArgumentParser(description=__doc__)
+parser.add_argument("--modified-since", metavar="REF")
+parser.add_argument(
+    "--format",
+    choices=("table", "matrix"),
+    default="table",
+    help="Output format: table (default) or matrix JSON.",
+)
+args = parser.parse_args()
 
+challenges = {
+    prefix / rel: rel
+    for challenge_dir in challenges_dir.glob("**/challenge")
+    if (rel := challenge_dir.parent.relative_to(challenges_dir).as_posix()) != "."
+}
 
-def run_git_command(*args: str) -> str:
-    result = subprocess.run(
-        ["git", *args],
-        cwd=REPO_ROOT,
-        check=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
+selected = sorted(challenges.values())
+if args.modified_since:
+    diff_output = subprocess.check_output(
+        ["git", "diff", "--name-only", args.modified_since],
+        cwd=repo_root,
         text=True,
     )
-    return result.stdout.strip()
-
-
-def determine_commit_range(
-    base_arg: str | None,
-    head_arg: str | None,
-) -> Tuple[str, str | None]:
-    if head_arg and not base_arg:
-        raise RuntimeError("HEAD reference requires BASE.")
-    if base_arg:
-        base = base_arg
-        head = head_arg  # None means compare with working tree
-    else:
-        head = "HEAD"
-        try:
-            upstream = run_git_command(
-                "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"
-            )
-        except subprocess.CalledProcessError:
-            upstream = None
-
-        if upstream:
-            base = run_git_command("merge-base", head, upstream)
-        else:
-            current_branch = run_git_command("rev-parse", "--abbrev-ref", "HEAD")
-            base_ref = "origin/main" if current_branch == "main" else "main"
-            run_git_command("rev-parse", "--verify", base_ref)
-            base = run_git_command("merge-base", head, base_ref)
-        head = "HEAD"
-
-    if base == EMPTY_TREE_SHA:
-        base = run_git_command("hash-object", "-t", "tree", "/dev/null")
-    if head == EMPTY_TREE_SHA:
-        head = run_git_command("hash-object", "-t", "tree", "/dev/null")
-    return base, head
-
-
-def list_changed_files(base: str, head: str | None) -> List[pathlib.PurePosixPath]:
-    args = ["diff", "--name-only", base]
-    if head:
-        args.append(head)
-    output = run_git_command(*args)
-    return [
-        pathlib.PurePosixPath(line)
-        for line in output.splitlines()
-        if line.strip()
+    changed = [
+        pathlib.PurePosixPath(line) for line in diff_output.splitlines() if line.strip()
     ]
-
-
-def discover_challenges(root: pathlib.Path) -> Dict[pathlib.PurePosixPath, str]:
-    if not root.is_dir():
-        raise RuntimeError(f"Challenges directory {root} not found")
-    challenges: Dict[pathlib.PurePosixPath, str] = {}
-    for dirpath, dirnames, _ in os.walk(root):
-        if "challenge" not in dirnames:
+    affected = set()
+    roots = list(challenges.keys())
+    for path in changed:
+        if not path.is_relative_to(prefix):
             continue
-        candidate = pathlib.Path(dirpath)
-        relative = candidate.relative_to(root)
-        if relative == pathlib.Path("."):
+        current = path
+        challenge = None
+        while True:
+            if current in challenges:
+                challenge = challenges[current]
+                break
+            if current == prefix or len(current.parts) < 2:
+                break
+            current = current.parent
+        if challenge:
+            affected.add(challenge)
             continue
-        rel_posix = relative.as_posix()
-        challenge_root = CHALLENGES_PREFIX / rel_posix
-        challenges[challenge_root] = rel_posix
-    return challenges
-
-
-def find_challenge_for_path(
-    path: pathlib.PurePosixPath, challenges: Dict[pathlib.PurePosixPath, str]
-) -> str | None:
-    current = path
-    while True:
-        if current in challenges:
-            return challenges[current]
-        if current == CHALLENGES_PREFIX or len(current.parts) < 2:
-            return None
-        current = current.parent
-
-
-def main(argv: Sequence[str]) -> int:
-    parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument(
-        "--only-modified",
-        dest="only_modified",
-        action="store_true",
-        help="List only challenges affected by git changes (default lists all).",
-    )
-    parser.add_argument(
-        "base",
-        nargs="?",
-        help="Git base reference (requires --only-modified).",
-    )
-    parser.add_argument(
-        "head",
-        nargs="?",
-        help="Git head reference (requires base and --only-modified).",
-    )
-
-    try:
-        args = parser.parse_args(argv[1:])
-        if not args.only_modified and (args.base or args.head):
-            parser.error("BASE/HEAD references require --only-modified.")
-
-        challenges = discover_challenges(CHALLENGES_DIR)
-        if not args.only_modified:
-            for challenge in sorted(challenges.values()):
-                print(challenge)
-            return 0
-
-        base, head = determine_commit_range(args.base, args.head)
-        changed_paths = list_changed_files(base, head)
-        if not changed_paths:
-            return 0
-
-        affected: Set[str] = set()
-        challenge_roots = list(challenges.keys())
-        for path in changed_paths:
-            if not path.is_relative_to(CHALLENGES_PREFIX):
-                continue
-            challenge = find_challenge_for_path(path, challenges)
-            if challenge:
-                affected.add(challenge)
-            try:
-                common_idx = path.parts.index("common", 1)
-            except ValueError:
-                continue
-            ancestor = pathlib.PurePosixPath(*path.parts[:common_idx])
-            for root in challenge_roots:
+        if "common" in path.parts[1:]:
+            ancestor = pathlib.PurePosixPath(*path.parts[: path.parts.index("common", 1)])
+            for root in roots:
                 if root.is_relative_to(ancestor):
                     affected.add(challenges[root])
-        for challenge in sorted(affected):
-            print(challenge)
-        return 0
-    except RuntimeError as exception:
-        print(exception, file=sys.stderr)
-        return 1
+    selected = sorted(affected)
 
+group_assignments = {rel: "default" for rel in challenges.values()}
+group_patterns = []
+for attr_file in sorted(challenges_dir.rglob(".gitattributes")):
+    base_rel = (
+        attr_file.parent.relative_to(challenges_dir).as_posix()
+        if attr_file.parent != challenges_dir
+        else ""
+    )
+    for line in attr_file.read_text().splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        try:
+            parts = shlex.split(stripped)
+        except ValueError:
+            continue
+        if len(parts) < 2:
+            continue
+        pattern, *tokens = parts
+        for token in tokens:
+            if token.startswith("filter=git-crypt-"):
+                group = token.split("=", 1)[1][len("git-crypt-") :]
+                combined = f"{base_rel}/{pattern}" if base_rel else pattern
+                group_patterns.append((combined, group))
 
-if __name__ == "__main__":
-    sys.exit(main(sys.argv))
+for pattern, group in group_patterns:
+    for match in challenges_dir.glob(pattern):
+        target = match if match.is_dir() else match.parent
+        while target != challenges_dir and target.parent != target:
+            rel = target.relative_to(challenges_dir).as_posix()
+            if rel in group_assignments:
+                if group_assignments[rel] == "default":
+                    group_assignments[rel] = group
+                break
+            target = target.parent
+
+rows = sorted(
+    (group_assignments.get(challenge, "default"), challenge) for challenge in selected
+)
+
+if args.format == "matrix":
+    grouped = {}
+    for group, challenge in rows:
+        grouped.setdefault(group, []).append(challenge)
+    matrix = {
+        "group": sorted(grouped),
+        "include": [
+            {"group": group, "challenges": "\n".join(sorted(challenges))}
+            for group, challenges in sorted(grouped.items())
+        ],
+    }
+    if not rows:
+        matrix = {"group": [], "include": []}
+    print(json.dumps(matrix, separators=(",", ":")))
+else:
+    group_width = (
+        max(len("GROUP"), *(len(group) for group, _ in rows)) if rows else len("GROUP")
+    )
+    path_width = (
+        max(len("PATH"), *(len(path) for _, path in rows)) if rows else len("PATH")
+    )
+    fmt = f"{{:<{group_width}}}  {{:<{path_width}}}"
+    print(fmt.format("GROUP", "PATH"))
+    for group, challenge in rows:
+        print(fmt.format(group, challenge))


### PR DESCRIPTION
This PR improves `ci/list-challenges` so that it also reports what group a challenge is in, and can export all of this information in a format useful for github actions (`--format matrix`).