### PR TITLE
ci: move docker storage to /mnt

### DIFF
--- a/.github/workflows/test-challenges.yml
+++ b/.github/workflows/test-challenges.yml
@@ -85,6 +85,17 @@ jobs:
       with:
         cache-dependency-glob: build
 
+    - name: Set up Docker storage
+      run: |
+        echo "::group::Current disk usage"
+        df -h
+        echo "::endgroup::"
+        sudo systemctl stop docker
+        sudo rm -rf /var/lib/docker
+        sudo mkdir -p /mnt/docker
+        sudo ln -s /mnt/docker /var/lib/docker
+        sudo systemctl start docker
+
     - name: Set up Docker
       uses: docker/setup-buildx-action@v3
 


### PR DESCRIPTION
There is significantly more storage available in the /mnt partition.