### PR TITLE
what-is-a-bug: switch to web.archive.org mirror

### DIFF
--- a/challenges/what-is-a-bug/bash-cve-2014-7186/challenge/Dockerfile
+++ b/challenges/what-is-a-bug/bash-cve-2014-7186/challenge/Dockerfile
@@ -13,9 +13,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     cmake python3-pwntools git build-essential wget bison flex gettext gawk perl file ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 # Fetch bash 4.3 source
-RUN wget -q https://ftp.gnu.org/gnu/bash/bash-4.3.tar.gz && \
+RUN wget -q https://web.archive.org/web/20141202112343/https://ftp.gnu.org/gnu/bash/bash-4.3.tar.gz && \
     tar -xzf /opt/bash-4.3.tar.gz -C /opt && rm /opt/bash-4.3.tar.gz
-RUN wget https://ftp.gnu.org/gnu/bash/bash-4.3-patches/bash43-027 -O /challenge/patch.diff
+RUN wget https://web.archive.org/web/20140930072819/http://ftp.gnu.org/gnu/bash/bash-4.3-patches/bash43-027 -O /challenge/patch.diff
 ADD --chown=0:0 --chmod=6755 http://github.com/pwncollege/exec-suid/releases/latest/download/exec-suid /usr/bin/exec-suid
 WORKDIR /opt/bash-4.3
 


### PR DESCRIPTION
https://ftp.gnu.org is down; hopefully https://web.archive.org will be more stable.