### PR TITLE
ci: report docker storage after tests

### DIFF
--- a/.github/workflows/test-challenges.yml
+++ b/.github/workflows/test-challenges.yml
@@ -119,3 +119,13 @@ jobs:
         ./pwnshop list "$CHALLENGE_DIR" --modified-since="$MODIFIED_SINCE"
         echo "::endgroup::"
         ./pwnshop test --jobs "$JOBS" --modified-since="$MODIFIED_SINCE" "$CHALLENGE_DIR"
+
+    - name: Report docker storage
+      if: always()
+      run: |
+        echo "::group::Disk usage (df -h)"
+        df -h
+        echo "::endgroup::"
+        echo "::group::Docker system usage"
+        docker system df -v
+        echo "::endgroup::"

--- a/.github/workflows/test-challenges.yml
+++ b/.github/workflows/test-challenges.yml
@@ -21,6 +21,7 @@ jobs:
     outputs:
       matrix: ${{ steps.challenge-matrix.outputs.matrix }}
       modified-since: ${{ steps.modified-since.outputs.ref }}
+      has-challenges: ${{ steps.challenge-matrix.outputs.has-challenges }}
 
     steps:
     - uses: actions/checkout@v4
@@ -66,10 +67,17 @@ jobs:
             | while read -r dir; do printf '{"directory":"challenges/%s"}\n' "$dir"; done \
             | paste -sd, -
         )"
-        echo "matrix={\"include\":[${matrix_entries}]}" >> "$GITHUB_OUTPUT"
+        if [ -z "$matrix_entries" ]; then
+          echo "matrix={\"include\":[{\"directory\":\"\"}]}" >> "$GITHUB_OUTPUT"
+          echo "has-challenges=false" >> "$GITHUB_OUTPUT"
+        else
+          echo "matrix={\"include\":[${matrix_entries}]}" >> "$GITHUB_OUTPUT"
+          echo "has-challenges=true" >> "$GITHUB_OUTPUT"
+        fi
 
   test-challenges:
     needs: detect-challenges
+    if: needs.detect-challenges.outputs.has-challenges == 'true'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false  # Continue testing other challenges even if one fails

--- a/.github/workflows/test-challenges.yml
+++ b/.github/workflows/test-challenges.yml
@@ -87,7 +87,7 @@ jobs:
 
     - name: Set up Docker storage
       run: |
-        echo "::group::Current disk usage"
+        echo "::group::Disk usage"
         df -h
         echo "::endgroup::"
         sudo systemctl stop docker
@@ -123,7 +123,7 @@ jobs:
     - name: Report docker storage
       if: always()
       run: |
-        echo "::group::Disk usage (df -h)"
+        echo "::group::Disk usage"
         df -h
         echo "::endgroup::"
         echo "::group::Docker system usage"

--- a/.github/workflows/test-challenges.yml
+++ b/.github/workflows/test-challenges.yml
@@ -63,22 +63,23 @@ jobs:
           ./pwnshop list ./challenges --modified-since="$MODIFIED_SINCE" \
             | cut -d/ -f1 \
             | sort -u \
-            | while read -r dir; do printf '{"directory":"challenges/%s"}\n' "$dir"; done \
+            | while read -r dir; do printf '"challenges/%s"\n' "$dir"; done \
             | paste -sd, -
         )"
         if [ -z "$matrix_entries" ]; then
-          echo "matrix={\"include\":[]}" >> "$GITHUB_OUTPUT"
+          echo "matrix=[]" >> "$GITHUB_OUTPUT"
         else
-          echo "matrix={\"include\":[${matrix_entries}]}" >> "$GITHUB_OUTPUT"
+          echo "matrix=[${matrix_entries}]" >> "$GITHUB_OUTPUT"
         fi
 
   test-challenges:
     needs: detect-challenges
-    if: ${{ fromJson(needs.detect-challenges.outputs.matrix).include }}
+    if: ${{ needs.detect-challenges.outputs.matrix != '[]' }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false  # Continue testing other challenges even if one fails
-      matrix: ${{ fromJson(needs.detect-challenges.outputs.matrix) }}
+      matrix:
+        challenges: ${{ fromJson(needs.detect-challenges.outputs.matrix) }}
 
     steps:
     - uses: actions/checkout@v4
@@ -115,7 +116,7 @@ jobs:
 
     - name: Test challenges in directory
       env:
-        CHALLENGE_DIR: ${{ matrix.directory }}
+        CHALLENGE_DIR: ${{ matrix.challenges }}
         MODIFIED_SINCE: ${{ needs.detect-challenges.outputs.modified-since }}
       run: |
         set -euo pipefail

--- a/.github/workflows/test-challenges.yml
+++ b/.github/workflows/test-challenges.yml
@@ -21,7 +21,6 @@ jobs:
     outputs:
       matrix: ${{ steps.challenge-matrix.outputs.matrix }}
       modified-since: ${{ steps.modified-since.outputs.ref }}
-      has-challenges: ${{ steps.challenge-matrix.outputs.has-challenges }}
 
     steps:
     - uses: actions/checkout@v4
@@ -68,16 +67,14 @@ jobs:
             | paste -sd, -
         )"
         if [ -z "$matrix_entries" ]; then
-          echo "matrix={\"include\":[{\"directory\":\"\"}]}" >> "$GITHUB_OUTPUT"
-          echo "has-challenges=false" >> "$GITHUB_OUTPUT"
+          echo "matrix={\"include\":[]}" >> "$GITHUB_OUTPUT"
         else
           echo "matrix={\"include\":[${matrix_entries}]}" >> "$GITHUB_OUTPUT"
-          echo "has-challenges=true" >> "$GITHUB_OUTPUT"
         fi
 
   test-challenges:
     needs: detect-challenges
-    if: needs.detect-challenges.outputs.has-challenges == 'true'
+    if: ${{ fromJson(needs.detect-challenges.outputs.matrix).include }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false  # Continue testing other challenges even if one fails

--- a/.github/workflows/test-challenges.yml
+++ b/.github/workflows/test-challenges.yml
@@ -66,11 +66,7 @@ jobs:
             | while read -r dir; do printf '"challenges/%s"\n' "$dir"; done \
             | paste -sd, -
         )"
-        if [ -z "$matrix_entries" ]; then
-          echo "matrix=[]" >> "$GITHUB_OUTPUT"
-        else
-          echo "matrix=[${matrix_entries}]" >> "$GITHUB_OUTPUT"
-        fi
+        echo "matrix=[${matrix_entries}]" >> "$GITHUB_OUTPUT"
 
   test-challenges:
     needs: detect-challenges


### PR DESCRIPTION
Adds a post-test storage report in CI so each run captures both filesystem usage and Docker system usage in grouped logs.

Also skips the test matrix entirely when no challenges are selected, preventing empty-matrix failures.