### PR TITLE
pwnshop: skip git-crypt files during render

### DIFF
--- a/tools/pwnshop/src/pwnshop/lib/__init__.py
+++ b/tools/pwnshop/src/pwnshop/lib/__init__.py
@@ -34,6 +34,7 @@ def render(template: pathlib.Path) -> str:
 
 def render_challenge(template_directory: pathlib.Path) -> pathlib.Path:
     rendered_directory = pathlib.Path(tempfile.mkdtemp(prefix="pwncollege-"))
+
     def ignore_git_crypt(current, names):
         return {
             name
@@ -41,6 +42,7 @@ def render_challenge(template_directory: pathlib.Path) -> pathlib.Path:
             if (path := pathlib.Path(current) / name).is_file()
             and path.open("rb").read(16).startswith(b"\x00GITCRYPT\x00")
         }
+
     shutil.copytree(template_directory, rendered_directory, dirs_exist_ok=True, ignore=ignore_git_crypt)
     for path in (path.relative_to(rendered_directory) for path in rendered_directory.rglob("*.j2")):
         destination = (rendered_directory / path).with_suffix("")

--- a/tools/pwnshop/src/pwnshop/lib/__init__.py
+++ b/tools/pwnshop/src/pwnshop/lib/__init__.py
@@ -34,8 +34,17 @@ def render(template: pathlib.Path) -> str:
 
 def render_challenge(template_directory: pathlib.Path) -> pathlib.Path:
     rendered_directory = pathlib.Path(tempfile.mkdtemp(prefix="pwncollege-"))
-    shutil.copytree(template_directory, rendered_directory, dirs_exist_ok=True)
-    for path in (path.relative_to(template_directory) for path in template_directory.rglob("*.j2")):
+
+    def ignore_git_crypt(current, names):
+        return {
+            name
+            for name in names
+            if (path := pathlib.Path(current) / name).is_file()
+            and path.open("rb").read(16).startswith(b"\x00GITCRYPT\x00")
+        }
+
+    shutil.copytree(template_directory, rendered_directory, dirs_exist_ok=True, ignore=ignore_git_crypt)
+    for path in (path.relative_to(rendered_directory) for path in rendered_directory.rglob("*.j2")):
         destination = (rendered_directory / path).with_suffix("")
         destination.write_text(render(template_directory / path))
         destination.chmod((template_directory / path).stat().st_mode)

--- a/tools/pwnshop/src/pwnshop/lib/__init__.py
+++ b/tools/pwnshop/src/pwnshop/lib/__init__.py
@@ -34,7 +34,6 @@ def render(template: pathlib.Path) -> str:
 
 def render_challenge(template_directory: pathlib.Path) -> pathlib.Path:
     rendered_directory = pathlib.Path(tempfile.mkdtemp(prefix="pwncollege-"))
-
     def ignore_git_crypt(current, names):
         return {
             name
@@ -42,7 +41,6 @@ def render_challenge(template_directory: pathlib.Path) -> pathlib.Path:
             if (path := pathlib.Path(current) / name).is_file()
             and path.open("rb").read(16).startswith(b"\x00GITCRYPT\x00")
         }
-
     shutil.copytree(template_directory, rendered_directory, dirs_exist_ok=True, ignore=ignore_git_crypt)
     for path in (path.relative_to(rendered_directory) for path in rendered_directory.rglob("*.j2")):
         destination = (rendered_directory / path).with_suffix("")


### PR DESCRIPTION
Skips git-crypt locked files during challenge rendering so templating does not choke on encrypted content when working without unlocked secrets.

Fixes #57.