### PR TITLE
ci: add challenge publish workflow

### DIFF
--- a/.github/actions/determine-modified-challenges/action.yml
+++ b/.github/actions/determine-modified-challenges/action.yml
@@ -39,6 +39,9 @@ runs:
       with:
         fetch-depth: 0
 
+    - uses: actions/checkout@v4
+      if: ${{ steps.resolve-ref.outputs.ref == '' }}
+
     - name: Install uv
       uses: astral-sh/setup-uv@v7
       with:

--- a/.github/actions/determine-modified-challenges/action.yml
+++ b/.github/actions/determine-modified-challenges/action.yml
@@ -39,9 +39,6 @@ runs:
       with:
         fetch-depth: 0
 
-    - uses: actions/checkout@v4
-      if: ${{ steps.resolve-ref.outputs.ref == '' }}
-
     - name: Install uv
       uses: astral-sh/setup-uv@v7
       with:

--- a/.github/actions/determine-modified-challenges/action.yml
+++ b/.github/actions/determine-modified-challenges/action.yml
@@ -1,0 +1,63 @@
+name: Determine modified challenges
+description: Determine modified challenges and group them by top-level directory.
+outputs:
+  modified_since_ref:
+    description: Base ref challenges have been modified since.
+    value: ${{ steps.resolve-ref.outputs.ref }}
+  challenges:
+    description: Top-level challenge groups.
+    value: ${{ steps.resolve-challenges.outputs.challenges }}
+runs:
+  using: composite
+  steps:
+    - uses: actions/github-script@v7
+      id: resolve-ref
+      with:
+        script: |
+          let ref = "";
+          if (context.eventName === "pull_request") {
+            ref = context.payload.pull_request.base.sha;
+          } else if (context.eventName === "push") {
+            const workflowFile = process.env.GITHUB_WORKFLOW_REF.split("@")[0].split("/").pop();
+            const branch = context.ref.replace("refs/heads/", "");
+            const { owner, repo } = context.repo;
+            const runs = await github.rest.actions.listWorkflowRuns({
+              owner,
+              repo,
+              workflow_id: workflowFile,
+              branch,
+              status: "success",
+              per_page: 1,
+            });
+            const [latest] = runs.data.workflow_runs;
+            ref = latest ? latest.head_sha : "";
+          }
+          core.setOutput("ref", ref);
+
+    - uses: actions/checkout@v4
+      if: ${{ steps.resolve-ref.outputs.ref != '' }}
+      with:
+        fetch-depth: 0
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v7
+      with:
+        cache-dependency-glob: tools/pwnshop/**
+
+    - uses: actions/github-script@v7
+      id: resolve-challenges
+      env:
+        MODIFIED_SINCE: ${{ steps.resolve-ref.outputs.ref }}
+      with:
+        script: |
+          const { execFileSync } = require("child_process");
+          const ref = process.env.MODIFIED_SINCE || "";
+          const output = execFileSync("./pwnshop", ["list", "./challenges", `--modified-since=${ref}`], {
+            stdio: ["ignore", "pipe", "inherit"],
+          })
+            .toString()
+            .trim();
+          const challenges = Array.from(
+            new Set(output.split("\n").map((line) => line.trim().split("/")[0]).filter(Boolean)),
+          ).sort();
+          core.setOutput("challenges", JSON.stringify(challenges));

--- a/.github/actions/report-docker-storage/action.yml
+++ b/.github/actions/report-docker-storage/action.yml
@@ -1,0 +1,15 @@
+name: Report docker storage
+description: Emit disk and Docker storage usage.
+runs:
+  using: composite
+  steps:
+    - name: Report docker storage
+      shell: bash
+      run: |
+        echo "::group::Disk usage"
+        df -h
+        echo "::endgroup::"
+        echo "::group::Docker system usage"
+        docker system df
+        docker system df -v
+        echo "::endgroup::"

--- a/.github/actions/setup-docker-storage/action.yml
+++ b/.github/actions/setup-docker-storage/action.yml
@@ -1,0 +1,16 @@
+name: Setup docker storage
+description: Move Docker storage to /mnt for more space.
+runs:
+  using: composite
+  steps:
+    - name: Set up Docker storage
+      shell: bash
+      run: |
+        echo "::group::Disk usage"
+        df -h
+        echo "::endgroup::"
+        sudo systemctl stop docker
+        sudo rm -rf /var/lib/docker
+        sudo mkdir -p /mnt/docker
+        sudo ln -s /mnt/docker /var/lib/docker
+        sudo systemctl start docker

--- a/.github/actions/test-challenges/action.yml
+++ b/.github/actions/test-challenges/action.yml
@@ -16,6 +16,9 @@ runs:
       with:
         fetch-depth: 0
 
+    - uses: actions/checkout@v4
+      if: ${{ inputs.modified_since_ref == '' }}
+
     - name: Install uv
       uses: astral-sh/setup-uv@v7
       with:

--- a/.github/actions/test-challenges/action.yml
+++ b/.github/actions/test-challenges/action.yml
@@ -16,9 +16,6 @@ runs:
       with:
         fetch-depth: 0
 
-    - uses: actions/checkout@v4
-      if: ${{ inputs.modified_since_ref == '' }}
-
     - name: Install uv
       uses: astral-sh/setup-uv@v7
       with:

--- a/.github/actions/test-challenges/action.yml
+++ b/.github/actions/test-challenges/action.yml
@@ -1,0 +1,47 @@
+name: Test challenges
+description: Test challenges.
+inputs:
+  challenges:
+    description: Top-level challenge group.
+    required: true
+  modified_since_ref:
+    description: Base ref challenges have been modified since.
+    required: false
+    default: ""
+runs:
+  using: composite
+  steps:
+    - uses: actions/checkout@v4
+      if: ${{ inputs.modified_since_ref != '' }}
+      with:
+        fetch-depth: 0
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v7
+      with:
+        cache-dependency-glob: tools/pwnshop/**
+
+    - name: Install git-crypt
+      shell: bash
+      run: |
+        sudo apt-get update && sudo apt-get install -y git-crypt
+
+    - name: Remove encrypted directories
+      shell: bash
+      run: |
+        git crypt status -e | sed -e "s/ *encrypted: //" | xargs dirname | xargs rm -rf
+
+    - name: Test challenges
+      shell: bash
+      env:
+        CHALLENGES_DIR: challenges/${{ inputs.challenges }}
+        MODIFIED_SINCE: ${{ inputs.modified_since_ref }}
+      run: |
+        set -euo pipefail
+        JOBS=$(( $(nproc) * 2 ))
+        echo "::group::Challenges to be tested"
+        ./pwnshop list "$CHALLENGES_DIR" --modified-since="$MODIFIED_SINCE"
+        echo "::endgroup::"
+        echo "::group::Testing challenges"
+        ./pwnshop test --jobs "$JOBS" --modified-since="$MODIFIED_SINCE" "$CHALLENGES_DIR"
+        echo "::endgroup::"

--- a/.github/workflows/publish-challenges.yml
+++ b/.github/workflows/publish-challenges.yml
@@ -1,14 +1,12 @@
-name: Test Challenges
+name: Publish Challenges
 
 on:
-  pull_request:
+  push:
     branches: [ main ]
   workflow_dispatch:
-  schedule:
-    - cron: '0 2 * * *'
 
 concurrency:
-  group: test-challenges-${{ github.ref }}
+  group: publish-challenges-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -17,14 +15,13 @@ jobs:
     outputs:
       challenges: ${{ steps.determine-modified-challenges.outputs.challenges }}
       modified_since_ref: ${{ steps.determine-modified-challenges.outputs.modified_since_ref }}
-
     steps:
     - name: Determine modified challenges
       id: determine-modified-challenges
       uses: ./.github/actions/determine-modified-challenges
 
 
-  test-challenges:
+  publish:
     needs: determine-modified-challenges
     if: ${{ needs.determine-modified-challenges.outputs.challenges != '[]' }}
     runs-on: ubuntu-latest
@@ -32,8 +29,15 @@ jobs:
       fail-fast: false
       matrix:
         challenges: ${{ fromJson(needs.determine-modified-challenges.outputs.challenges) }}
-
     steps:
+    - name: Login to registry
+      if: false
+      uses: docker/login-action@v3
+      with:
+        registry: ${{ secrets.REGISTRY_HOST }}
+        username: ${{ secrets.REGISTRY_USER }}
+        password: ${{ secrets.REGISTRY_PASSWORD }}
+
     - name: Set up Docker storage
       uses: ./.github/actions/setup-docker-storage
 
@@ -44,7 +48,24 @@ jobs:
       uses: ./.github/actions/test-challenges
       with:
         challenges: ${{ matrix.challenges }}
-        modified_since_ref: ${{ needs.determine-modified-challenges.outputs.modified_since_ref }}
+        modified_since_ref: ""
+
+    - name: Publish challenges
+      env:
+        CHALLENGES_DIR: challenges/${{ matrix.challenges }}
+        REGISTRY_HOST: ${{ secrets.REGISTRY_HOST }}
+        GIT_SHA: ${{ github.sha }}
+      run: |
+        set -euo pipefail
+        while IFS= read -r challenge; do
+          image_id="$(./pwnshop build "$CHALLENGES_DIR/$challenge")"
+          challenge_slug="${CHALLENGES_DIR#challenges/}/$challenge"
+          repo="$REGISTRY_HOST/$challenge_slug"
+          docker tag "$image_id" "$repo:$GIT_SHA"
+          # docker push "$repo:$GIT_SHA"
+          docker tag "$image_id" "$repo:latest"
+          # docker push "$repo:latest"
+        done < <(./pwnshop list "$CHALLENGES_DIR")
 
     - name: Report docker storage
       if: always()

--- a/.github/workflows/publish-challenges.yml
+++ b/.github/workflows/publish-challenges.yml
@@ -16,6 +16,10 @@ jobs:
       challenges: ${{ steps.determine-modified-challenges.outputs.challenges }}
       modified_since_ref: ${{ steps.determine-modified-challenges.outputs.modified_since_ref }}
     steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 1
+
     - name: Determine modified challenges
       id: determine-modified-challenges
       uses: ./.github/actions/determine-modified-challenges
@@ -30,6 +34,10 @@ jobs:
       matrix:
         challenges: ${{ fromJson(needs.determine-modified-challenges.outputs.challenges) }}
     steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 1
+
     - name: Login to registry
       if: false
       uses: docker/login-action@v3

--- a/.github/workflows/publish-challenges.yml
+++ b/.github/workflows/publish-challenges.yml
@@ -17,8 +17,6 @@ jobs:
       modified_since_ref: ${{ steps.determine-modified-challenges.outputs.modified_since_ref }}
     steps:
     - uses: actions/checkout@v4
-      with:
-        fetch-depth: 1
 
     - name: Determine modified challenges
       id: determine-modified-challenges
@@ -35,8 +33,6 @@ jobs:
         challenges: ${{ fromJson(needs.determine-modified-challenges.outputs.challenges) }}
     steps:
     - uses: actions/checkout@v4
-      with:
-        fetch-depth: 1
 
     - name: Login to registry
       if: false

--- a/.github/workflows/test-challenges.yml
+++ b/.github/workflows/test-challenges.yml
@@ -20,8 +20,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-      with:
-        fetch-depth: 1
 
     - name: Determine modified challenges
       id: determine-modified-challenges
@@ -39,8 +37,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-      with:
-        fetch-depth: 1
 
     - name: Set up Docker storage
       uses: ./.github/actions/setup-docker-storage

--- a/.github/workflows/test-challenges.yml
+++ b/.github/workflows/test-challenges.yml
@@ -19,6 +19,10 @@ jobs:
       modified_since_ref: ${{ steps.determine-modified-challenges.outputs.modified_since_ref }}
 
     steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 1
+
     - name: Determine modified challenges
       id: determine-modified-challenges
       uses: ./.github/actions/determine-modified-challenges
@@ -34,6 +38,10 @@ jobs:
         challenges: ${{ fromJson(needs.determine-modified-challenges.outputs.challenges) }}
 
     steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 1
+
     - name: Set up Docker storage
       uses: ./.github/actions/setup-docker-storage
 

--- a/tools/pwnshop/src/pwnshop/commands/build.py
+++ b/tools/pwnshop/src/pwnshop/commands/build.py
@@ -28,4 +28,4 @@ def build_command(targets, modified_since):
             image_id = lib.build_challenge(challenge_path)
         except RuntimeError as error:
             raise click.ClickException(str(error)) from error
-        console.print(f"[green]Built[/] {image_id}")
+        click.echo(image_id)


### PR DESCRIPTION
Adds shared CI actions for determining modified challenge groups, running tests, and reporting docker storage, plus a publish workflow that tests before building images. pwnshop build now prints only the image ID, and registry login/pushes are disabled for now.