### PR TITLE
ci: increase docker storage capacity

### DIFF
--- a/.github/actions/determine-modified-challenges/action.yml
+++ b/.github/actions/determine-modified-challenges/action.yml
@@ -58,6 +58,15 @@ runs:
             .toString()
             .trim();
           const challenges = Array.from(
-            new Set(output.split("\n").map((line) => line.trim().split("/")[0]).filter(Boolean)),
+            new Set(
+              output
+                .split("\n")
+                .map((line) => {
+                  const parts = line.trim().split("/");
+                  if (parts[0] === "legacy") return `legacy/${parts[1]}`;
+                  return parts[0];
+                })
+                .filter(Boolean),
+            ),
           ).sort();
           core.setOutput("challenges", JSON.stringify(challenges));

--- a/.github/actions/report-docker-storage/action.yml
+++ b/.github/actions/report-docker-storage/action.yml
@@ -13,3 +13,9 @@ runs:
         docker system df
         docker system df -v
         echo "::endgroup::"
+        echo "::group::Docker storage contents"
+        sudo sh -c 'du -sh /var/lib/docker/* 2>/dev/null || true'
+        echo "::endgroup::"
+        echo "::group::Containerd storage contents"
+        sudo sh -c 'du -sh /var/lib/containerd/* 2>/dev/null || true'
+        echo "::endgroup::"

--- a/.github/actions/setup-docker-storage/action.yml
+++ b/.github/actions/setup-docker-storage/action.yml
@@ -10,7 +10,11 @@ runs:
         df -h
         echo "::endgroup::"
         sudo systemctl stop docker
-        sudo rm -rf /var/lib/docker
-        sudo mkdir -p /mnt/docker
-        sudo ln -s /mnt/docker /var/lib/docker
+        sudo systemctl stop containerd
+        sudo sh -c 'echo "{\"features\":{\"containerd-snapshotter\":true}}" > /etc/docker/daemon.json'
+        for service in docker containerd; do
+          sudo rm -rf "/var/lib/$service"
+          sudo mkdir -p "/mnt/$service"
+          sudo ln -s "/mnt/$service" "/var/lib/$service"
+        done
         sudo systemctl start docker


### PR DESCRIPTION
This updates CI storage handling by moving Docker’s data root to /mnt, enabling the containerd snapshotter, adding du summaries for Docker and containerd storage to aid diagnostics, and ensuring legacy/* changes are grouped as module-scoped in the modified-challenges matrix.