### PR TITLE
ci: publish challenges to r2

### DIFF
--- a/.github/workflows/publish-challenges.yml
+++ b/.github/workflows/publish-challenges.yml
@@ -85,12 +85,12 @@ jobs:
             | xargs -r docker image inspect --format '{{.Id}} {{index .Config.Labels "pwncollege.challenge"}}'
         )
 
-        # echo "::group::rclone blobs"
-        # rclone copy "$publish_blobs_dir" "r2:${R2_BUCKET_NAME}/blobs" --ignore-existing --stats 10s --stats-one-line
-        # echo "::endgroup::"
-        # echo "::group::rclone manifests"
-        # rclone copy "$publish_manifests_dir" "r2:${R2_BUCKET_NAME}/manifests" --stats 10s --stats-one-line
-        # echo "::endgroup::"
+        echo "::group::rclone blobs"
+        rclone copy "$publish_blobs_dir" "r2:${R2_BUCKET_NAME}/blobs" --ignore-existing --stats 10s --stats-one-line
+        echo "::endgroup::"
+        echo "::group::rclone manifests"
+        rclone copy "$publish_manifests_dir" "r2:${R2_BUCKET_NAME}/manifests" --stats 10s --stats-one-line
+        echo "::endgroup::"
 
     - name: Report docker storage
       if: always()

--- a/.github/workflows/publish-challenges.yml
+++ b/.github/workflows/publish-challenges.yml
@@ -54,14 +54,23 @@ jobs:
         challenges: ${{ matrix.challenges }}
         modified_since_ref: ""
 
+    - name: Install rclone
+      run: sudo apt-get update && sudo apt-get install -y rclone
+
     - name: Publish challenges
       env:
         CHALLENGES_DIR: challenges/${{ matrix.challenges }}
+        R2_BUCKET_NAME: ${{ secrets.R2_BUCKET_NAME }}
+        RCLONE_CONFIG_R2_TYPE: s3
+        RCLONE_CONFIG_R2_PROVIDER: Cloudflare
+        RCLONE_CONFIG_R2_ENDPOINT: https://${{ secrets.R2_ACCOUNT_ID }}.r2.cloudflarestorage.com
+        RCLONE_CONFIG_R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY }}
+        RCLONE_CONFIG_R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_KEY }}
       run: |
         set -euo pipefail
         containerd_blobs_dir="/var/lib/containerd/io.containerd.content.v1.content/blobs/sha256"
         publish_blobs_dir="/mnt/publish/blobs"
-        publish_manifests_dir="/mnt/publish/manifets"
+        publish_manifests_dir="/mnt/publish/manifests"
         sudo mkdir -p "$publish_blobs_dir" "$publish_manifests_dir"
         while IFS= read -r challenge; do
           image_id="$(./pwnshop build "$CHALLENGES_DIR/$challenge")"
@@ -77,17 +86,12 @@ jobs:
                 "$containerd_blobs_dir/$digest" 2>/dev/null
             )
           done
-          manifest_dir="$publish_manifests_dir/$challenge_slug"
-          sudo mkdir -p "$manifest_dir"
-          sudo ln -sfn "$publish_blobs_dir/$image_id" "$manifest_dir/latest"
-
+          sudo mkdir -p "$publish_manifests_dir/$challenge_slug"
+          printf '%s\n' "$image_id" | sudo tee "$publish_manifests_dir/$challenge_slug/latest" >/dev/null
         done < <(./pwnshop list "$CHALLENGES_DIR")
-        echo "::group::Publish manifests"
-        find "$publish_manifests_dir" -type l -print0 | sort -z | xargs -0 -I{} sh -c 'printf "%s -> %s\n" "{}" "$(readlink "{}")"'
-        echo "::endgroup::"
-        echo "::group::Publish blob storage"
-        du -sh "$publish_blobs_dir"
-        echo "::endgroup::"
+
+        rclone copy "$publish_blobs_dir" "r2:${R2_BUCKET_NAME}/blobs" --ignore-existing
+        rclone copy "$publish_manifests_dir" "r2:${R2_BUCKET_NAME}/manifests"
 
     - name: Report docker storage
       if: always()

--- a/.github/workflows/publish-challenges.yml
+++ b/.github/workflows/publish-challenges.yml
@@ -57,19 +57,37 @@ jobs:
     - name: Publish challenges
       env:
         CHALLENGES_DIR: challenges/${{ matrix.challenges }}
-        REGISTRY_HOST: ${{ secrets.REGISTRY_HOST }}
-        GIT_SHA: ${{ github.sha }}
       run: |
         set -euo pipefail
+        containerd_blobs_dir="/var/lib/containerd/io.containerd.content.v1.content/blobs/sha256"
+        publish_blobs_dir="/mnt/publish/blobs"
+        publish_manifests_dir="/mnt/publish/manifets"
+        sudo mkdir -p "$publish_blobs_dir" "$publish_manifests_dir"
         while IFS= read -r challenge; do
           image_id="$(./pwnshop build "$CHALLENGES_DIR/$challenge")"
+          image_id="${image_id#sha256:}"
           challenge_slug="${CHALLENGES_DIR#challenges/}/$challenge"
-          repo="$REGISTRY_HOST/$challenge_slug"
-          docker tag "$image_id" "$repo:$GIT_SHA"
-          # docker push "$repo:$GIT_SHA"
-          docker tag "$image_id" "$repo:latest"
-          # docker push "$repo:latest"
+          stack=("$image_id")
+          while ((${#stack[@]})); do
+            digest="${stack[-1]}"
+            unset 'stack[-1]'
+            sudo ln "$containerd_blobs_dir/$digest" "$publish_blobs_dir/$digest" 2>/dev/null || true
+            mapfile -t -O "${#stack[@]}" stack < <(
+              sudo jq -r '.manifests[]?.digest,.config.digest?,.layers[]?.digest? | select(type=="string") | sub("^sha256:";"")' \
+                "$containerd_blobs_dir/$digest" 2>/dev/null
+            )
+          done
+          manifest_dir="$publish_manifests_dir/$challenge_slug"
+          sudo mkdir -p "$manifest_dir"
+          sudo ln -sfn "$publish_blobs_dir/$image_id" "$manifest_dir/latest"
+
         done < <(./pwnshop list "$CHALLENGES_DIR")
+        echo "::group::Publish manifests"
+        find "$publish_manifests_dir" -type l -print0 | sort -z | xargs -0 -I{} sh -c 'printf "%s -> %s\n" "{}" "$(readlink "{}")"'
+        echo "::endgroup::"
+        echo "::group::Publish blob storage"
+        du -sh "$publish_blobs_dir"
+        echo "::endgroup::"
 
     - name: Report docker storage
       if: always()

--- a/.github/workflows/publish-challenges.yml
+++ b/.github/workflows/publish-challenges.yml
@@ -73,9 +73,9 @@ jobs:
         publish_manifests_dir="/mnt/publish/manifests"
         sudo mkdir -p "$publish_blobs_dir" "$publish_manifests_dir"
         while IFS= read -r challenge; do
+          challenge_slug="${CHALLENGES_DIR#challenges/}/$challenge"
           image_id="$(./pwnshop build "$CHALLENGES_DIR/$challenge")"
           image_id="${image_id#sha256:}"
-          challenge_slug="${CHALLENGES_DIR#challenges/}/$challenge"
           stack=("$image_id")
           while ((${#stack[@]})); do
             digest="${stack[-1]}"

--- a/.github/workflows/publish-challenges.yml
+++ b/.github/workflows/publish-challenges.yml
@@ -34,14 +34,6 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Login to registry
-      if: false
-      uses: docker/login-action@v3
-      with:
-        registry: ${{ secrets.REGISTRY_HOST }}
-        username: ${{ secrets.REGISTRY_USER }}
-        password: ${{ secrets.REGISTRY_PASSWORD }}
-
     - name: Set up Docker storage
       uses: ./.github/actions/setup-docker-storage
 

--- a/.github/workflows/publish-challenges.yml
+++ b/.github/workflows/publish-challenges.yml
@@ -66,15 +66,14 @@ jobs:
         sudo mkdir -p "$publish_blobs_dir" "$publish_manifests_dir"
         while IFS= read -r line; do
           image_id="${line%% *}"
-          image_id="${image_id#sha256:}"
           challenge_slug="${line#* }"
           stack=("$image_id")
           while ((${#stack[@]})); do
-            digest="${stack[-1]}"
+            digest="${stack[-1]#sha256:}"
             unset 'stack[-1]'
             sudo ln "$containerd_blobs_dir/$digest" "$publish_blobs_dir/$digest" 2>/dev/null || continue
             mapfile -t -O "${#stack[@]}" stack < <(
-              sudo jq -r '.manifests[]?.digest,.config.digest?,.layers[]?.digest? | select(type=="string") | sub("^sha256:";"")' \
+              sudo jq -r '.manifests[]?.digest,.config.digest?,.layers[]?.digest? | select(type=="string")' \
                 "$containerd_blobs_dir/$digest" 2>/dev/null
             )
           done

--- a/.github/workflows/publish-challenges.yml
+++ b/.github/workflows/publish-challenges.yml
@@ -90,8 +90,12 @@ jobs:
           printf '%s\n' "$image_id" | sudo tee "$publish_manifests_dir/$challenge_slug/latest" >/dev/null
         done < <(./pwnshop list "$CHALLENGES_DIR")
 
-        rclone copy "$publish_blobs_dir" "r2:${R2_BUCKET_NAME}/blobs" --ignore-existing
-        rclone copy "$publish_manifests_dir" "r2:${R2_BUCKET_NAME}/manifests"
+        echo "::group::rclone blobs"
+        rclone copy "$publish_blobs_dir" "r2:${R2_BUCKET_NAME}/blobs" --ignore-existing --stats 10s --stats-one-line
+        echo "::endgroup::"
+        echo "::group::rclone manifests"
+        rclone copy "$publish_manifests_dir" "r2:${R2_BUCKET_NAME}/manifests" --stats 10s --stats-one-line
+        echo "::endgroup::"
 
     - name: Report docker storage
       if: always()

--- a/.github/workflows/publish-challenges.yml
+++ b/.github/workflows/publish-challenges.yml
@@ -72,10 +72,10 @@ jobs:
         publish_blobs_dir="/mnt/publish/blobs"
         publish_manifests_dir="/mnt/publish/manifests"
         sudo mkdir -p "$publish_blobs_dir" "$publish_manifests_dir"
-        while IFS= read -r challenge; do
-          challenge_slug="${CHALLENGES_DIR#challenges/}/$challenge"
-          image_id="$(./pwnshop build "$CHALLENGES_DIR/$challenge")"
+        while IFS= read -r line; do
+          image_id="${line%% *}"
           image_id="${image_id#sha256:}"
+          challenge_slug="${line#* }"
           stack=("$image_id")
           while ((${#stack[@]})); do
             digest="${stack[-1]}"
@@ -88,7 +88,10 @@ jobs:
           done
           sudo mkdir -p "$publish_manifests_dir/$challenge_slug"
           printf '%s\n' "$image_id" | sudo tee "$publish_manifests_dir/$challenge_slug/latest" >/dev/null
-        done < <(./pwnshop list "$CHALLENGES_DIR")
+        done < <(
+          docker image ls --filter "label=pwncollege.challenge" --no-trunc --quiet \
+            | xargs -r docker image inspect --format '{{.Id}} {{index .Config.Labels "pwncollege.challenge"}}'
+        )
 
         echo "::group::rclone blobs"
         rclone copy "$publish_blobs_dir" "r2:${R2_BUCKET_NAME}/blobs" --ignore-existing --stats 10s --stats-one-line

--- a/.github/workflows/publish-challenges.yml
+++ b/.github/workflows/publish-challenges.yml
@@ -93,12 +93,12 @@ jobs:
             | xargs -r docker image inspect --format '{{.Id}} {{index .Config.Labels "pwncollege.challenge"}}'
         )
 
-        echo "::group::rclone blobs"
-        rclone copy "$publish_blobs_dir" "r2:${R2_BUCKET_NAME}/blobs" --ignore-existing --stats 10s --stats-one-line
-        echo "::endgroup::"
-        echo "::group::rclone manifests"
-        rclone copy "$publish_manifests_dir" "r2:${R2_BUCKET_NAME}/manifests" --stats 10s --stats-one-line
-        echo "::endgroup::"
+        # echo "::group::rclone blobs"
+        # rclone copy "$publish_blobs_dir" "r2:${R2_BUCKET_NAME}/blobs" --ignore-existing --stats 10s --stats-one-line
+        # echo "::endgroup::"
+        # echo "::group::rclone manifests"
+        # rclone copy "$publish_manifests_dir" "r2:${R2_BUCKET_NAME}/manifests" --stats 10s --stats-one-line
+        # echo "::endgroup::"
 
     - name: Report docker storage
       if: always()

--- a/.github/workflows/publish-challenges.yml
+++ b/.github/workflows/publish-challenges.yml
@@ -72,7 +72,7 @@ jobs:
           while ((${#stack[@]})); do
             digest="${stack[-1]}"
             unset 'stack[-1]'
-            sudo ln "$containerd_blobs_dir/$digest" "$publish_blobs_dir/$digest" 2>/dev/null || true
+            sudo ln "$containerd_blobs_dir/$digest" "$publish_blobs_dir/$digest" 2>/dev/null || continue
             mapfile -t -O "${#stack[@]}" stack < <(
               sudo jq -r '.manifests[]?.digest,.config.digest?,.layers[]?.digest? | select(type=="string") | sub("^sha256:";"")' \
                 "$containerd_blobs_dir/$digest" 2>/dev/null

--- a/tools/pwnshop/src/pwnshop/lib/__init__.py
+++ b/tools/pwnshop/src/pwnshop/lib/__init__.py
@@ -122,8 +122,16 @@ def run_challenge(
 def build_challenge(challenge_path: pathlib.Path) -> str:
     rendered_directory = render_challenge(challenge_path)
     try:
+        label = challenge_path.as_posix().removeprefix("challenges/")
         image_id = subprocess.check_output(
-            ["docker", "build", "-q", str(rendered_directory / "challenge")],
+            [
+                "docker",
+                "build",
+                "-q",
+                "--label",
+                f"pwncollege.challenge={label}",
+                str(rendered_directory / "challenge"),
+            ],
             text=True,
         ).strip()
         return image_id


### PR DESCRIPTION
Publish now walks image blob graphs into /mnt/publish/blobs, writes per-challenge latest digest files under /mnt/publish/manifests, and syncs both to R2.

```
Tag / Digest
   ↓
Image Index        (optional)
   ↓
Image Manifest
   ↓
 ┌─────────────┬─────────────┐
 ↓             ↓             ↓
Config blob   Layer blob   Layer blob
```
