### PR TITLE
registry: redirect blobs to public r2

### DIFF
--- a/services/registry/src/index.js
+++ b/services/registry/src/index.js
@@ -50,13 +50,10 @@ export default {
           return new Response("Not found", { status: 404 });
         }
 
-        const blobKey = `blobs/${ref.replace(":", "/")}`;
-        const signedUrl = await env.REGISTRY_BUCKET.createSignedUrl(blobKey, {
-          method: request.method,
-          expiresIn: 3600,
-        });
-
-        return Response.redirect(signedUrl, 307);
+        return Response.redirect(
+          new URL(`blobs/${ref.replace(":", "/")}`, `https://${env.R2_DOMAIN}`).toString(),
+          307
+        );
       }
 
       default:

--- a/services/registry/wrangler.toml
+++ b/services/registry/wrangler.toml
@@ -4,6 +4,9 @@ compatibility_date = "2025-02-01"
 workers_dev = false
 routes = [{ pattern = "challenges.pwn.college", custom_domain = true }]
 
+[vars]
+R2_DOMAIN = "cdn.challenges.pwn.college"
+
 [[r2_buckets]]
 binding = "REGISTRY_BUCKET"
 bucket_name = "challenges-registry"


### PR DESCRIPTION
Redirect blob requests to the public R2 domain at cdn.challenges.pwn.college.