### PR TITLE
ci: use nix fmt

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -7,23 +7,28 @@ on:
     branches: [ main, master ]
 
 jobs:
-  pwnshop:
+  nix-fmt:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
 
-    - name: Install uv
-      uses: astral-sh/setup-uv@v7
-      with:
-        cache-dependency-glob: tools/pwnshop/**
+    - name: Install Nix
+      uses: DeterminateSystems/determinate-nix-action@v3
 
-    - name: Install Ruff
-      run: |
-        uv tool install --force ruff
-        echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+    - name: Enable Magic Nix Cache
+      uses: DeterminateSystems/magic-nix-cache-action@v13
 
-    - name: Check pwnshop
-      working-directory: tools/pwnshop
+    - name: nix fmt (must be clean)
       run: |
-        ruff check
-        ruff format --check --diff
+        set -euo pipefail
+        nix fmt --no-write-lock-file
+        if [ -n "$(git status --porcelain)" ]; then
+          echo "::error::nix fmt produced changes. Run 'nix fmt' locally and commit the result."
+          echo ""
+          echo "git status:"
+          git status --porcelain
+          echo ""
+          echo "git diff:"
+          git --no-pager diff
+          exit 1
+        fi

--- a/.treefmt.toml
+++ b/.treefmt.toml
@@ -1,0 +1,10 @@
+on-unmatched = "info"
+
+[formatter.nix]
+command = "nixfmt"
+includes = ["*.nix", "**/*.nix"]
+
+[formatter.python]
+command = "ruff"
+options = ["format", "--line-length", "120"]
+includes = ["tools/**/*.py", "tools/maintainers/*"]

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,27 @@
       forAllSystems = f: lib.genAttrs systems (system: f system);
     in
     {
-      devShells = forAllSystems (system:
+      formatter = forAllSystems (
+        system:
+        let
+          pkgs = import nixpkgs { inherit system; };
+        in
+        pkgs.writeShellApplication {
+          name = "fmt";
+          runtimeInputs = [
+            pkgs.nixfmt-rfc-style
+            pkgs.ruff
+            pkgs.treefmt
+          ];
+          text = ''
+            set -euo pipefail
+            exec treefmt "$@"
+          '';
+        }
+      );
+
+      devShells = forAllSystems (
+        system:
         let
           pkgs = import nixpkgs { inherit system; };
 
@@ -46,6 +66,7 @@
               export DOCKER_HOST="$(sudo ${pwn-challenge-runtime}/bin/pwn-challenge-runtime)"
             '';
           };
-        });
+        }
+      );
     };
 }

--- a/runtime/default.nix
+++ b/runtime/default.nix
@@ -15,16 +15,17 @@ let
     pkgs.writeText unitFileName (lib.generators.toINI { listsAsDuplicateKeys = true; } sections);
 
   kataConfigToml =
-    pkgs.runCommand "${name}-kata-config.toml" { nativeBuildInputs = [ pkgs.gawk ]; } ''
-      kernel_line="$(awk '$1 == "kernel" { print; exit }' ${pkgs.kata-runtime}/share/defaults/kata-containers/configuration.toml)"
-      substitute ${pkgs.kata-runtime}/share/defaults/kata-containers/configuration.toml "$out" \
-        --replace-fail \
-          "$kernel_line" \
-          'kernel = "${kataKernel}/share/kata-containers/vmlinux.container"' \
-        --replace-fail \
-          'enable_annotations = ["enable_iommu", "virtio_fs_extra_args", "kernel_params"]' \
-          'enable_annotations = ["enable_iommu", "virtio_fs_extra_args", "kernel_params", "default_memory"]'
-    '';
+    pkgs.runCommand "${name}-kata-config.toml" { nativeBuildInputs = [ pkgs.gawk ]; }
+      ''
+        kernel_line="$(awk '$1 == "kernel" { print; exit }' ${pkgs.kata-runtime}/share/defaults/kata-containers/configuration.toml)"
+        substitute ${pkgs.kata-runtime}/share/defaults/kata-containers/configuration.toml "$out" \
+          --replace-fail \
+            "$kernel_line" \
+            'kernel = "${kataKernel}/share/kata-containers/vmlinux.container"' \
+          --replace-fail \
+            'enable_annotations = ["enable_iommu", "virtio_fs_extra_args", "kernel_params"]' \
+            'enable_annotations = ["enable_iommu", "virtio_fs_extra_args", "kernel_params", "default_memory"]'
+      '';
 
   dockerDaemonJson = jsonFormat.generate "${name}-docker-daemon.json" {
     "data-root" = dataRoot;

--- a/runtime/kernel.nix
+++ b/runtime/kernel.nix
@@ -5,10 +5,13 @@ let
     hash = "sha256-+SppAF77NbXlSrBGvIm40AmNC12GrexbX7fAPBoDAcs=";
   };
 
-  kernelVersion = builtins.readFile "${pkgs.runCommand "kata-kernel-version" { nativeBuildInputs = [ pkgs.yq ]; } ''
-    version="$(yq -r '.assets.kernel.version' ${kataContainersSrc}/versions.yaml)"
-    printf '%s' "''${version#v}" > "$out"
-  ''}";
+  kernelVersion = builtins.readFile "${pkgs.runCommand "kata-kernel-version"
+    { nativeBuildInputs = [ pkgs.yq ]; }
+    ''
+      version="$(yq -r '.assets.kernel.version' ${kataContainersSrc}/versions.yaml)"
+      printf '%s' "''${version#v}" > "$out"
+    ''
+  }";
   kernelMajor = builtins.elemAt (pkgs.lib.splitString "." kernelVersion) 0;
   kernelTarball = pkgs.fetchurl {
     url = "http://cdn.kernel.org/pub/linux/kernel/v${kernelMajor}.x/linux-${kernelVersion}.tar.xz";

--- a/tools/maintainers/check-maintainers
+++ b/tools/maintainers/check-maintainers
@@ -31,6 +31,7 @@ PGP_END = "-----END PGP PUBLIC KEY BLOCK-----"
 
 UNIQUE_MAINTAINER_FIELDS = ["name", "github", "key", "email"]
 
+
 class Maintainer(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -39,13 +40,9 @@ class Maintainer(BaseModel):
         pattern=r"^[a-z\d](?:[a-z\d-]{0,37}[a-z\d])?$",
         description="1-39 lowercase letters, digits, or hyphens, and cannot begin or end with a hyphen",
     )
-    groups: List[str] = Field(
-        min_length=1, description="a non-empty list of glob patterns"
-    )
+    groups: List[str] = Field(min_length=1, description="a non-empty list of glob patterns")
     key: str = Field(description="a valid ASCII-armored PGP public key block")
-    email: Optional[EmailStr] = Field(
-        default=None, description="a valid email address, if provided"
-    )
+    email: Optional[EmailStr] = Field(default=None, description="a valid email address, if provided")
 
     @field_validator("key")
     @classmethod
@@ -102,11 +99,7 @@ try:
     maintainers = yaml.safe_load(maintainers_path.read_text())
 except yaml.YAMLError as e:
     print(
-        (
-            "## ❌ Issues found in `maintainers.yml`\n"
-            "YAML parse error:\n"
-            f"\n```\n{e}\n```"
-        ),
+        (f"## ❌ Issues found in `maintainers.yml`\nYAML parse error:\n\n```\n{e}\n```"),
         file=open(GITHUB_STEP_SUMMARY, "a") if GITHUB_STEP_SUMMARY else sys.stderr,
     )
     sys.exit(1)
@@ -131,18 +124,14 @@ except ValidationError as e:
                 details.append(f"\n### Maintainer at index {maintainer_index}:")
             else:
                 name = maintainers[maintainer_index]["name"]
-                details.append(
-                    f"\n### Maintainer named `{name}` (at index {maintainer_index}):"
-                )
+                details.append(f"\n### Maintainer named `{name}` (at index {maintainer_index}):")
             for field, error in errors.items():
                 if error["type"] == "extra_forbidden":
                     details.append(f"- **{field}** is not a valid field")
                     continue
                 field_description = Maintainer.model_fields[field].description
                 if error["type"] == "missing":
-                    details.append(
-                        f"- **{field}** is required, but missing ({field_description})"
-                    )
+                    details.append(f"- **{field}** is required, but missing ({field_description})")
                 else:
                     details.append(f"- **{field}** is invalid ({field_description})")
 
@@ -158,9 +147,7 @@ for field in UNIQUE_MAINTAINER_FIELDS:
     for maintainer in maintainers:
         shared_values.setdefault(maintainer.get(field), []).append(maintainer)
     duplicate_values = {
-        value: maintainers
-        for value, maintainers in shared_values.items()
-        if value is not None and len(maintainers) > 1
+        value: maintainers for value, maintainers in shared_values.items() if value is not None and len(maintainers) > 1
     }
     for duplicate_maintainers in duplicate_values.values():
         duplicate_value_errors.setdefault(field, []).append(duplicate_maintainers)

--- a/tools/maintainers/sync-maintainers
+++ b/tools/maintainers/sync-maintainers
@@ -13,9 +13,7 @@ import sys
 
 import yaml
 
-repository_root = pathlib.Path(
-    subprocess.check_output(["git", "rev-parse", "--show-toplevel"], text=True).strip()
-)
+repository_root = pathlib.Path(subprocess.check_output(["git", "rev-parse", "--show-toplevel"], text=True).strip())
 
 maintainers_path = repository_root / "maintainers.yml"
 maintainers = yaml.safe_load(maintainers_path.read_text())
@@ -37,11 +35,7 @@ for maintainer in maintainers:
         input=maintainer["key"],
     )
     fingerprint = next(
-        (
-            line.split(":")[9].upper()
-            for line in key_metadata.splitlines()
-            if line.startswith("fpr:")
-        ),
+        (line.split(":")[9].upper() for line in key_metadata.splitlines() if line.startswith("fpr:")),
         None,
     )
 
@@ -54,9 +48,7 @@ for maintainer in maintainers:
     )
 
     maintainer_groups = [
-        group
-        for group in all_groups
-        if any(fnmatch.fnmatchcase(group, pattern) for pattern in maintainer["groups"])
+        group for group in all_groups if any(fnmatch.fnmatchcase(group, pattern) for pattern in maintainer["groups"])
     ]
 
     for group in maintainer_groups:

--- a/tools/pwnshop/pyproject.toml
+++ b/tools/pwnshop/pyproject.toml
@@ -14,10 +14,3 @@ dependencies = [
 
 [project.scripts]
 pwnshop = "pwnshop:cli"
-
-[tool.ruff]
-line-length = 120
-src = ["src"]
-
-[tool.ruff.lint.isort]
-known-first-party = ["pwnshop"]

--- a/tools/pwnshop/src/pwnshop/__main__.py
+++ b/tools/pwnshop/src/pwnshop/__main__.py
@@ -1,5 +1,4 @@
 from pwnshop import cli
 
-
 if __name__ == "__main__":
     cli(prog_name="pwnshop")

--- a/tools/pwnshop/src/pwnshop/commands/test.py
+++ b/tools/pwnshop/src/pwnshop/commands/test.py
@@ -5,6 +5,7 @@ import os
 import pathlib
 import shutil
 import subprocess
+
 import click
 from rich.progress import (
     BarColumn,
@@ -14,6 +15,7 @@ from rich.progress import (
     TimeElapsedColumn,
     TimeRemainingColumn,
 )
+
 from .. import lib
 from ..console import console
 


### PR DESCRIPTION
Switch CI formatting enforcement to flake-provided `nix fmt` (treefmt + ruff + nixfmt).

- Add flake `formatter` so `nix fmt` works locally and in CI
- Add `.treefmt.toml` to format Nix + Python (including `tools/maintainers/*` uv scripts)
- Update Code Quality workflow to run `nix fmt` and fail with `git diff` if it would change files
