### PR TITLE
ci: target main only

### DIFF
--- a/.github/workflows/check-encryption.yml
+++ b/.github/workflows/check-encryption.yml
@@ -2,7 +2,7 @@ name: Check Encryption
 
 on:
   push:
-    branches: [ main, master ]
+    branches: [ main ]
   pull_request:
 
 jobs:

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main ]
 
 jobs:
   nix-fmt:

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -2,9 +2,9 @@ name: Code Quality
 
 on:
   push:
-    branches: [ main, master ]
+    branches: [ main ]
   pull_request:
-    branches: [ main, master ]
+    branches: [ main ]
 
 jobs:
   nix-fmt:

--- a/.github/workflows/test-challenges.yml
+++ b/.github/workflows/test-challenges.yml
@@ -2,7 +2,6 @@ name: Test Challenges
 
 on:
   pull_request:
-    branches: [ main ]
   workflow_dispatch:
   schedule:
     - cron: '0 2 * * *'


### PR DESCRIPTION
Update GitHub Actions branch filters to target only `main`.

This removes the `master` branch from workflow triggers.
