### PR TITLE
ci: publish challenge image to dojo as latest

### DIFF
--- a/tools/dojo/update-dojo
+++ b/tools/dojo/update-dojo
@@ -63,7 +63,7 @@ def main() -> int:
             image = f"{args.registry}/{slug}:latest"
             if manifests_dir and (latest_path := manifests_dir / slug / "latest").exists():
                 digest = latest_path.read_text().strip()
-                image = f"{args.registry}/{slug}:latest@{digest}"
+                image = f"{image}@{digest}"
             resource["image"] = image
 
     dojo_id = spec["id"]

--- a/tools/dojo/update-dojo
+++ b/tools/dojo/update-dojo
@@ -60,9 +60,12 @@ def main() -> int:
                 continue
             challenge_id = resource.get("id")
             slug = f"{dojo_prefix}/{module_id}/{challenge_id}"
-            image = f"{args.registry}/{slug}"
+            image_base = f"{args.registry}/{slug}"
+            # Always publish as ":latest" for Dojo. If we have a digest, pin it too.
+            image = f"{image_base}:latest"
             if manifests_dir and (latest_path := manifests_dir / slug / "latest").exists():
-                image = f"{image}@{latest_path.read_text().strip()}"
+                digest = latest_path.read_text().strip()
+                image = f"{image_base}:latest@{digest}"
             resource["image"] = image
 
     dojo_id = spec["id"]

--- a/tools/dojo/update-dojo
+++ b/tools/dojo/update-dojo
@@ -60,12 +60,10 @@ def main() -> int:
                 continue
             challenge_id = resource.get("id")
             slug = f"{dojo_prefix}/{module_id}/{challenge_id}"
-            image_base = f"{args.registry}/{slug}"
-            # Always publish as ":latest" for Dojo. If we have a digest, pin it too.
-            image = f"{image_base}:latest"
+            image = f"{args.registry}/{slug}:latest"
             if manifests_dir and (latest_path := manifests_dir / slug / "latest").exists():
                 digest = latest_path.read_text().strip()
-                image = f"{image_base}:latest@{digest}"
+                image = f"{args.registry}/{slug}:latest@{digest}"
             resource["image"] = image
 
     dojo_id = spec["id"]


### PR DESCRIPTION
Update Dojo challenge image references to always include the :latest tag; when a published digest is available via manifests, pin it as :latest@<digest>. This ensures the pulled images are tagged (and so will not be pruned).