### PR TITLE
ci: remove digest from image for dojo update

### DIFF
--- a/.github/workflows/publish-challenges.yml
+++ b/.github/workflows/publish-challenges.yml
@@ -104,7 +104,7 @@ jobs:
         CHALLENGES_DIR: challenges/${{ matrix.challenges }}
         DOJO_URL: https://pwn.college
         DOJO_TOKEN: ${{ secrets.DOJO_TOKEN }}
-      run: ./tools/dojo/update-dojo --manifests /mnt/publish/manifests --registry challenges.pwn.college "$CHALLENGES_DIR/dojo.yml"
+      run: ./tools/dojo/update-dojo --registry challenges.pwn.college "$CHALLENGES_DIR/dojo.yml"
 
     - name: Report docker storage
       if: always()

--- a/tools/dojo/update-dojo
+++ b/tools/dojo/update-dojo
@@ -19,7 +19,6 @@ import requests
 
 def main() -> int:
     parser = argparse.ArgumentParser(description="Update a Dojo via the Dojo update endpoint.")
-    parser.add_argument("--manifests", type=pathlib.Path, help="Directory containing published manifest tag files.")
     parser.add_argument("--registry", required=True, help="Registry hostname for published images.")
     parser.add_argument("dojo_yml", type=pathlib.Path, help="Path to dojo.yml.")
     args = parser.parse_args()
@@ -52,7 +51,6 @@ def main() -> int:
 
     spec = json.loads(parse_result.stdout)
 
-    manifests_dir = args.manifests
     for module in spec.get("modules", []):
         module_id = module.get("id")
         for resource in module.get("resources", []):
@@ -60,10 +58,7 @@ def main() -> int:
                 continue
             challenge_id = resource.get("id")
             slug = f"{dojo_prefix}/{module_id}/{challenge_id}"
-            image = f"{args.registry}/{slug}"
-            if manifests_dir and (latest_path := manifests_dir / slug / "latest").exists():
-                image = f"{image}@{latest_path.read_text().strip()}"
-            resource["image"] = image
+            resource["image"] = f"{args.registry}/{slug}:latest"
 
     dojo_id = spec["id"]
     update_url = f"{dojo_url}/pwncollege_api/v1/dojos/{dojo_id}/update"


### PR DESCRIPTION
If we push an image with a digest, it doesn't get tagged (even if we use a syntax like `:latest@sha256:...`). Then the dojo wants to prune it. For now, we just won't digest tag when publishing updates to the dojo.