### PR TITLE
ci: publish nix cache

### DIFF
--- a/.github/workflows/publish-nix-cache.yml
+++ b/.github/workflows/publish-nix-cache.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Enable Magic Nix Cache
       uses: DeterminateSystems/magic-nix-cache-action@v13
 
-    - name: Build dev shell output
+    - name: Build devshell
       id: build-devshell
       run: |
         set -euo pipefail

--- a/.github/workflows/publish-nix-cache.yml
+++ b/.github/workflows/publish-nix-cache.yml
@@ -27,7 +27,10 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Install Nix
-      uses: cachix/install-nix-action@v31
+      uses: DeterminateSystems/determinate-nix-action@v3
+
+    - name: Enable Magic Nix Cache
+      uses: DeterminateSystems/magic-nix-cache-action@v13
 
     - name: Build dev shell output
       id: resolve-devshell-out

--- a/.github/workflows/publish-nix-cache.yml
+++ b/.github/workflows/publish-nix-cache.yml
@@ -43,12 +43,12 @@ jobs:
         AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_KEY }}
         AWS_EC2_METADATA_DISABLED: "true"
-        NIX_CACHE_SIGNING_PRIVATE_KEY: ${{ secrets.NIX_CACHE_SIGNING_PRIVATE_KEY }}
+        NIX_CACHE_PRIVATE_KEY: ${{ secrets.NIX_CACHE_PRIVATE_KEY }}
       run: |
         set -euo pipefail
 
         signing_key_file="${RUNNER_TEMP}/nix-cache-private-key"
-        printf '%s\n' "${NIX_CACHE_SIGNING_PRIVATE_KEY}" > "${signing_key_file}"
+        printf '%s\n' "${NIX_CACHE_PRIVATE_KEY}" > "${signing_key_file}"
         chmod 600 "${signing_key_file}"
 
         nix copy --to "s3://${R2_BUCKET_NAME}?scheme=https&endpoint=${R2_ENDPOINT}&region=auto&secret-key=${signing_key_file}" '${{ steps.build-dev-shell.outputs.path }}'

--- a/.github/workflows/publish-nix-cache.yml
+++ b/.github/workflows/publish-nix-cache.yml
@@ -49,22 +49,13 @@ jobs:
       run: |
         set -euo pipefail
 
-        if [[ -z "${NIX_CACHE_SIGNING_PRIVATE_KEY}" ]]; then
-          echo "Missing required secret: NIX_CACHE_SIGNING_PRIVATE_KEY" >&2
-          exit 1
-        fi
-
         signing_key_file="${RUNNER_TEMP}/nix-cache-private-key"
         printf '%s\n' "${NIX_CACHE_SIGNING_PRIVATE_KEY}" > "${signing_key_file}"
         chmod 600 "${signing_key_file}"
 
-        cache_store="s3://${R2_BUCKET_NAME}?scheme=https&endpoint=${R2_ENDPOINT}&region=auto&secret-key=${signing_key_file}"
-        dev_shell_out='${{ steps.build-dev-shell.outputs.path }}'
-
-        nix copy --to "${cache_store}" "${dev_shell_out}"
+        nix copy --to "s3://${R2_BUCKET_NAME}?scheme=https&endpoint=${R2_ENDPOINT}&region=auto&secret-key=${signing_key_file}" '${{ steps.build-dev-shell.outputs.path }}'
 
     - name: Check cache availability from public domain
       run: |
         set -euo pipefail
-        dev_shell_out='${{ steps.build-dev-shell.outputs.path }}'
-        nix path-info --store "https://${R2_PUBLIC_CACHE_DOMAIN}" "${dev_shell_out}" >/dev/null
+        nix path-info --store "https://${R2_PUBLIC_CACHE_DOMAIN}" '${{ steps.build-dev-shell.outputs.path }}' >/dev/null

--- a/.github/workflows/publish-nix-cache.yml
+++ b/.github/workflows/publish-nix-cache.yml
@@ -33,7 +33,7 @@ jobs:
       uses: DeterminateSystems/magic-nix-cache-action@v13
 
     - name: Build dev shell output
-      id: resolve-devshell-out
+      id: build-devshell
       run: |
         set -euo pipefail
         printf 'path=%s\n' "$(nix build --no-link --print-out-paths .#devShells.x86_64-linux.default)" >> "${GITHUB_OUTPUT}"
@@ -59,12 +59,12 @@ jobs:
         chmod 600 "${signing_key_file}"
 
         cache_store="s3://${R2_BUCKET_NAME}?scheme=https&endpoint=${R2_ENDPOINT}&region=auto&secret-key=${signing_key_file}"
-        devshell_out='${{ steps.resolve-devshell-out.outputs.path }}'
+        devshell_out='${{ steps.build-devshell.outputs.path }}'
 
         nix copy --to "${cache_store}" "${devshell_out}"
 
     - name: Check cache availability from public domain
       run: |
         set -euo pipefail
-        devshell_out='${{ steps.resolve-devshell-out.outputs.path }}'
+        devshell_out='${{ steps.build-devshell.outputs.path }}'
         nix path-info --store "https://${R2_PUBLIC_CACHE_DOMAIN}" "${devshell_out}" >/dev/null

--- a/.github/workflows/publish-nix-cache.yml
+++ b/.github/workflows/publish-nix-cache.yml
@@ -15,7 +15,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  publish-devshell-cache:
+  publish-dev-shell-cache:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -32,8 +32,8 @@ jobs:
     - name: Enable Magic Nix Cache
       uses: DeterminateSystems/magic-nix-cache-action@v13
 
-    - name: Build devshell
-      id: build-devshell
+    - name: Build dev shell
+      id: build-dev-shell
       run: |
         set -euo pipefail
         printf 'path=%s\n' "$(nix build --no-link --print-out-paths .#devShells.x86_64-linux.default)" >> "${GITHUB_OUTPUT}"
@@ -59,12 +59,12 @@ jobs:
         chmod 600 "${signing_key_file}"
 
         cache_store="s3://${R2_BUCKET_NAME}?scheme=https&endpoint=${R2_ENDPOINT}&region=auto&secret-key=${signing_key_file}"
-        devshell_out='${{ steps.build-devshell.outputs.path }}'
+        dev_shell_out='${{ steps.build-dev-shell.outputs.path }}'
 
-        nix copy --to "${cache_store}" "${devshell_out}"
+        nix copy --to "${cache_store}" "${dev_shell_out}"
 
     - name: Check cache availability from public domain
       run: |
         set -euo pipefail
-        devshell_out='${{ steps.build-devshell.outputs.path }}'
-        nix path-info --store "https://${R2_PUBLIC_CACHE_DOMAIN}" "${devshell_out}" >/dev/null
+        dev_shell_out='${{ steps.build-dev-shell.outputs.path }}'
+        nix path-info --store "https://${R2_PUBLIC_CACHE_DOMAIN}" "${dev_shell_out}" >/dev/null

--- a/.github/workflows/publish-nix-cache.yml
+++ b/.github/workflows/publish-nix-cache.yml
@@ -7,7 +7,7 @@ on:
       - flake.nix
       - flake.lock
       - runtime/**
-      - pwnshop
+      - tools/pwnshop/**
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/publish-nix-cache.yml
+++ b/.github/workflows/publish-nix-cache.yml
@@ -42,8 +42,6 @@ jobs:
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_KEY }}
-        AWS_REGION: auto
-        AWS_DEFAULT_REGION: auto
         AWS_EC2_METADATA_DISABLED: "true"
         NIX_CACHE_SIGNING_PRIVATE_KEY: ${{ secrets.NIX_CACHE_SIGNING_PRIVATE_KEY }}
       run: |

--- a/.github/workflows/publish-nix-cache.yml
+++ b/.github/workflows/publish-nix-cache.yml
@@ -1,0 +1,67 @@
+name: Publish Nix Cache
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - flake.nix
+      - flake.lock
+      - runtime/**
+      - pwnshop
+  workflow_dispatch:
+
+concurrency:
+  group: publish-nix-cache-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  publish-devshell-cache:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      R2_BUCKET_NAME: challenges-nix-cache
+      R2_PUBLIC_CACHE_DOMAIN: nix-cache.challenges.pwn.college
+      R2_ENDPOINT: ${{ secrets.R2_ACCOUNT_ID }}.r2.cloudflarestorage.com
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install Nix
+      uses: cachix/install-nix-action@v31
+
+    - name: Build dev shell output
+      id: resolve-devshell-out
+      run: |
+        set -euo pipefail
+        printf 'path=%s\n' "$(nix build --no-link --print-out-paths .#devShells.x86_64-linux.default)" >> "${GITHUB_OUTPUT}"
+
+    - name: Publish dev shell closure to R2 cache
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_KEY }}
+        AWS_REGION: auto
+        AWS_DEFAULT_REGION: auto
+        AWS_EC2_METADATA_DISABLED: "true"
+        NIX_CACHE_SIGNING_PRIVATE_KEY: ${{ secrets.NIX_CACHE_SIGNING_PRIVATE_KEY }}
+      run: |
+        set -euo pipefail
+
+        if [[ -z "${NIX_CACHE_SIGNING_PRIVATE_KEY}" ]]; then
+          echo "Missing required secret: NIX_CACHE_SIGNING_PRIVATE_KEY" >&2
+          exit 1
+        fi
+
+        signing_key_file="${RUNNER_TEMP}/nix-cache-private-key"
+        printf '%s\n' "${NIX_CACHE_SIGNING_PRIVATE_KEY}" > "${signing_key_file}"
+        chmod 600 "${signing_key_file}"
+
+        cache_store="s3://${R2_BUCKET_NAME}?scheme=https&endpoint=${R2_ENDPOINT}&region=auto&secret-key=${signing_key_file}"
+        devshell_out='${{ steps.resolve-devshell-out.outputs.path }}'
+
+        nix copy --to "${cache_store}" "${devshell_out}"
+
+    - name: Check cache availability from public domain
+      run: |
+        set -euo pipefail
+        devshell_out='${{ steps.resolve-devshell-out.outputs.path }}'
+        nix path-info --store "https://${R2_PUBLIC_CACHE_DOMAIN}" "${devshell_out}" >/dev/null

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,13 @@
 {
   description = "pwn.college challenges dev env";
 
+  nixConfig = {
+    extra-substituters = [ "https://nix-cache.challenges.pwn.college" ];
+    extra-trusted-public-keys = [
+      "nix-cache.challenges.pwn.college-1:Qj32MyanSS2fW+W7MtEFN3fWSksMT8l6IyJuG9Lw5bc="
+    ];
+  };
+
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
   };


### PR DESCRIPTION
## Summary
- add a new `Publish Nix Cache` workflow for the flake dev shell closure
- publish to the R2 S3 bucket `challenges-nix-cache` via `nix copy`
- verify published paths are reachable through `https://nix-cache.challenges.pwn.college`

## Details
- workflow runs on pushes to `main` when `flake.nix`, `flake.lock`, `runtime/**`, or `tools/pwnshop/**` change
- uses existing R2 secrets (`R2_ACCOUNT_ID`, `R2_ACCESS_KEY`, `R2_SECRET_KEY`)
- adds one required signing secret: `NIX_CACHE_PRIVATE_KEY`
