### PR TITLE
runtime: use custom seccomp

### DIFF
--- a/runtime/default.nix
+++ b/runtime/default.nix
@@ -9,60 +9,7 @@ let
   jsonFormat = pkgs.formats.json { };
 
   kataKernel = import ./kernel.nix { inherit pkgs name; };
-
-  seccompBaseProfile = pkgs.fetchurl {
-    # Pin the upstream Docker seccomp base profile so nix builds stay reproducible.
-    url = "https://raw.githubusercontent.com/moby/profiles/9fb516320ad275f544b4995f424dfa8b6261cffa/seccomp/default.json";
-    hash = "sha256-AVNvHR35OK5hHrog1jSeDeepm27N7hVJQnoLAbgwHig=";
-  };
-
-  seccompProfileScript = pkgs.writeText "${name}-seccomp.py" ''
-    import json
-    import sys
-
-    READ_IMPLIES_EXEC = 0x0400000
-    ADDR_NO_RANDOMIZE = 0x0040000
-
-    with open(sys.argv[1]) as profile_file:
-        seccomp = json.load(profile_file)
-
-    existing_personality_values = []
-    for syscalls in seccomp["syscalls"]:
-        if "personality" not in syscalls["names"]:
-            continue
-        if syscalls["action"] != "SCMP_ACT_ALLOW":
-            continue
-        assert len(syscalls["args"]) == 1
-        arg = syscalls["args"][0]
-        assert list(arg.keys()) == ["index", "value", "op"]
-        assert arg["index"] == 0, arg
-        assert arg["op"] == "SCMP_CMP_EQ"
-        existing_personality_values.append(arg["value"])
-
-    new_personality_values = []
-    for new_flag in [READ_IMPLIES_EXEC, ADDR_NO_RANDOMIZE]:
-        for value in [0, *existing_personality_values]:
-            new_value = value | new_flag
-            if new_value not in existing_personality_values:
-                new_personality_values.append(new_value)
-                existing_personality_values.append(new_value)
-
-    for new_value in new_personality_values:
-        seccomp["syscalls"].append(
-            {
-                "names": ["personality"],
-                "action": "SCMP_ACT_ALLOW",
-                "args": [{"index": 0, "value": new_value, "op": "SCMP_CMP_EQ"}],
-            }
-        )
-
-    with open(sys.argv[2], "w") as out_file:
-        json.dump(seccomp, out_file)
-  '';
-
-  seccompProfile = pkgs.runCommand "${name}-seccomp.json" { nativeBuildInputs = [ pkgs.python3 ]; } ''
-    python ${seccompProfileScript} ${seccompBaseProfile} "$out"
-  '';
+  seccompProfile = import ./seccomp.nix { inherit pkgs name; };
 
   toSystemdUnit =
     unitFileName: sections:

--- a/runtime/default.nix
+++ b/runtime/default.nix
@@ -10,6 +10,60 @@ let
 
   kataKernel = import ./kernel.nix { inherit pkgs name; };
 
+  seccompBaseProfile = pkgs.fetchurl {
+    # Pin the upstream Docker seccomp base profile so nix builds stay reproducible.
+    url = "https://raw.githubusercontent.com/moby/profiles/9fb516320ad275f544b4995f424dfa8b6261cffa/seccomp/default.json";
+    hash = "sha256-AVNvHR35OK5hHrog1jSeDeepm27N7hVJQnoLAbgwHig=";
+  };
+
+  seccompProfileScript = pkgs.writeText "${name}-seccomp.py" ''
+    import json
+    import sys
+
+    READ_IMPLIES_EXEC = 0x0400000
+    ADDR_NO_RANDOMIZE = 0x0040000
+
+    with open(sys.argv[1]) as profile_file:
+        seccomp = json.load(profile_file)
+
+    existing_personality_values = []
+    for syscalls in seccomp["syscalls"]:
+        if "personality" not in syscalls["names"]:
+            continue
+        if syscalls["action"] != "SCMP_ACT_ALLOW":
+            continue
+        assert len(syscalls["args"]) == 1
+        arg = syscalls["args"][0]
+        assert list(arg.keys()) == ["index", "value", "op"]
+        assert arg["index"] == 0, arg
+        assert arg["op"] == "SCMP_CMP_EQ"
+        existing_personality_values.append(arg["value"])
+
+    new_personality_values = []
+    for new_flag in [READ_IMPLIES_EXEC, ADDR_NO_RANDOMIZE]:
+        for value in [0, *existing_personality_values]:
+            new_value = value | new_flag
+            if new_value not in existing_personality_values:
+                new_personality_values.append(new_value)
+                existing_personality_values.append(new_value)
+
+    for new_value in new_personality_values:
+        seccomp["syscalls"].append(
+            {
+                "names": ["personality"],
+                "action": "SCMP_ACT_ALLOW",
+                "args": [{"index": 0, "value": new_value, "op": "SCMP_CMP_EQ"}],
+            }
+        )
+
+    with open(sys.argv[2], "w") as out_file:
+        json.dump(seccomp, out_file)
+  '';
+
+  seccompProfile = pkgs.runCommand "${name}-seccomp.json" { nativeBuildInputs = [ pkgs.python3 ]; } ''
+    python ${seccompProfileScript} ${seccompBaseProfile} "$out"
+  '';
+
   toSystemdUnit =
     unitFileName: sections:
     pkgs.writeText unitFileName (lib.generators.toINI { listsAsDuplicateKeys = true; } sections);
@@ -32,6 +86,7 @@ let
     "exec-root" = runRoot;
     "pidfile" = "${runRoot}/dockerd.pid";
     "log-driver" = "journald";
+    "seccomp-profile" = "${seccompProfile}";
 
     "features" = {
       "containerd-snapshotter" = true;

--- a/runtime/seccomp.nix
+++ b/runtime/seccomp.nix
@@ -1,7 +1,6 @@
 { pkgs, name }:
 let
   seccompBaseProfile = pkgs.fetchurl {
-    # Pin the upstream Docker seccomp base profile so nix builds stay reproducible.
     url = "https://raw.githubusercontent.com/moby/profiles/9fb516320ad275f544b4995f424dfa8b6261cffa/seccomp/default.json";
     hash = "sha256-AVNvHR35OK5hHrog1jSeDeepm27N7hVJQnoLAbgwHig=";
   };

--- a/runtime/seccomp.nix
+++ b/runtime/seccomp.nix
@@ -1,0 +1,55 @@
+{ pkgs, name }:
+let
+  seccompBaseProfile = pkgs.fetchurl {
+    # Pin the upstream Docker seccomp base profile so nix builds stay reproducible.
+    url = "https://raw.githubusercontent.com/moby/profiles/9fb516320ad275f544b4995f424dfa8b6261cffa/seccomp/default.json";
+    hash = "sha256-AVNvHR35OK5hHrog1jSeDeepm27N7hVJQnoLAbgwHig=";
+  };
+
+  seccompProfileScript = pkgs.writeText "${name}-seccomp.py" ''
+    import json
+    import sys
+
+    READ_IMPLIES_EXEC = 0x0400000
+    ADDR_NO_RANDOMIZE = 0x0040000
+
+    with open(sys.argv[1]) as profile_file:
+        seccomp = json.load(profile_file)
+
+    existing_personality_values = []
+    for syscalls in seccomp["syscalls"]:
+        if "personality" not in syscalls["names"]:
+            continue
+        if syscalls["action"] != "SCMP_ACT_ALLOW":
+            continue
+        assert len(syscalls["args"]) == 1
+        arg = syscalls["args"][0]
+        assert list(arg.keys()) == ["index", "value", "op"]
+        assert arg["index"] == 0, arg
+        assert arg["op"] == "SCMP_CMP_EQ"
+        existing_personality_values.append(arg["value"])
+
+    new_personality_values = []
+    for new_flag in [READ_IMPLIES_EXEC, ADDR_NO_RANDOMIZE]:
+        for value in [0, *existing_personality_values]:
+            new_value = value | new_flag
+            if new_value not in existing_personality_values:
+                new_personality_values.append(new_value)
+                existing_personality_values.append(new_value)
+
+    for new_value in new_personality_values:
+        seccomp["syscalls"].append(
+            {
+                "names": ["personality"],
+                "action": "SCMP_ACT_ALLOW",
+                "args": [{"index": 0, "value": new_value, "op": "SCMP_CMP_EQ"}],
+            }
+        )
+
+    with open(sys.argv[2], "w") as out_file:
+        json.dump(seccomp, out_file)
+  '';
+in
+pkgs.runCommand "${name}-seccomp.json" { nativeBuildInputs = [ pkgs.python3 ]; } ''
+  python ${seccompProfileScript} ${seccompBaseProfile} "$out"
+''


### PR DESCRIPTION
## Summary
- move the custom seccomp handling from per-container `pwnshop` flags to the runtime docker daemon config in Nix
- generate a pinned custom seccomp profile from the upstream moby default profile and extend `personality` allowances with `READ_IMPLIES_EXEC` and `ADDR_NO_RANDOMIZE` variants
- set daemon `seccomp-profile` so all runtime containers inherit this policy by default

## Validation
- `nix run .#formatter.x86_64-linux -- runtime/default.nix`
- `nix-build --no-out-link -E 'let flake = builtins.getFlake \"/home/kanak/projects/pwn.college/challenges/work/runtime-use-custom-seccomp\"; pkgs = import flake.inputs.nixpkgs { system = \"x86_64-linux\"; }; lib = pkgs.lib; in import /home/kanak/projects/pwn.college/challenges/work/runtime-use-custom-seccomp/runtime/default.nix { inherit pkgs lib; }' --impure`\n- inspected generated daemon config/profile to confirm `seccomp-profile` is set and personality values were expanded