### PR TITLE
legacy: add key

### DIFF
--- a/.git-crypt/keys/legacy/0/A6C1BD8AA19BE7CC1B05DD6E1E180F029DD5460F.gpg
+++ b/.git-crypt/keys/legacy/0/A6C1BD8AA19BE7CC1B05DD6E1E180F029DD5460F.gpg
@@ -1,0 +1,1 @@
+„^âr{¥4õ@Hxà¦Ü.`êqÏãŠ£Àj_¡ç˜ŠkZã±å oE:?0nŸv¤Ã*ÀÇ.‰Äê8Ÿ'1{?%ÌyQ½V,bÒÛúK©{&ÑœâáPrÚdÔÀ	´§Ùì},A&O	úîë°¾–edpÁáDÓK¶,²PNX… z>lp o`ç/æq„\ƒÉæ'êÄ›¤½áoŠxª•r/\ïA†ÀêMÞµ‹¶ GØ±Ámp–rBž„$.²åÈª³ŠÏ»-\²Á£Èêº-"Æž³Ø¶:µÓÈ‘µvÒ#Æ²3Í‰¾¯{Î9qÓ—.!;+h°þKi5¥H¦fCz>ÿwóZ|âR9HYPå™5Å?Ç1¬âE¶‹/îÛÃ

--- a/challenges/legacy/.gitattributes
+++ b/challenges/legacy/.gitattributes
@@ -1,0 +1,1 @@
+**/tests_private/** filter=git-crypt-legacy diff=git-crypt-legacy


### PR DESCRIPTION
Split legacy git-crypt key material into its own PR.

Changes:
- add challenges/legacy/.gitattributes
- add .git-crypt/keys/legacy/0/A6C1BD8AA19BE7CC1B05DD6E1E180F029DD5460F.gpg