### PR TITLE
ci: fix sync maintainers key detection

### DIFF
--- a/.github/workflows/sync-maintainers.yml
+++ b/.github/workflows/sync-maintainers.yml
@@ -1,13 +1,14 @@
 name: Sync Maintainers
 
 on:
+  workflow_dispatch:
   push:
     branches: [ main ]
     paths:
       - "maintainers.yml"
       - "tools/maintainers/sync-maintainers"
       - ".github/workflows/sync-maintainers.yml"
-      - ".git-crypt/keys/*/A6C1BD8AA19BE7CC1B05DD6E1E180F029DD5460F.gpg"
+      - ".git-crypt/keys/**/A6C1BD8AA19BE7CC1B05DD6E1E180F029DD5460F.gpg"
 
 permissions:
   contents: write

--- a/.github/workflows/sync-maintainers.yml
+++ b/.github/workflows/sync-maintainers.yml
@@ -1,7 +1,6 @@
 name: Sync Maintainers
 
 on:
-  workflow_dispatch:
   push:
     branches: [ main ]
     paths:
@@ -9,6 +8,7 @@ on:
       - "tools/maintainers/sync-maintainers"
       - ".github/workflows/sync-maintainers.yml"
       - ".git-crypt/keys/**/A6C1BD8AA19BE7CC1B05DD6E1E180F029DD5460F.gpg"
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
Fix sync-maintainers trigger matching for git-crypt key additions and add a manual run option.

Changes:
- fix key path glob from `.git-crypt/keys/*/...` to `.git-crypt/keys/**/...`
- add `workflow_dispatch` trigger so this workflow can be run manually from Actions UI