### PR TITLE
ci: fix r2 auth for nix cache publish

### DIFF
--- a/.github/workflows/publish-nix-cache.yml
+++ b/.github/workflows/publish-nix-cache.yml
@@ -47,11 +47,24 @@ jobs:
       run: |
         set -euo pipefail
 
+        aws_dir="${HOME}/.aws"
+        mkdir -p "${aws_dir}"
+        {
+          printf '%s\n' '[default]'
+          printf '%s\n' "aws_access_key_id=${AWS_ACCESS_KEY_ID}"
+          printf '%s\n' "aws_secret_access_key=${AWS_SECRET_ACCESS_KEY}"
+        } > "${aws_dir}/credentials"
+        {
+          printf '%s\n' '[default]'
+          printf '%s\n' 'region = auto'
+        } > "${aws_dir}/config"
+        chmod 600 "${aws_dir}/credentials" "${aws_dir}/config"
+
         signing_key_file="${RUNNER_TEMP}/nix-cache-private-key"
         printf '%s\n' "${NIX_CACHE_PRIVATE_KEY}" > "${signing_key_file}"
         chmod 600 "${signing_key_file}"
 
-        nix copy --to "s3://${R2_BUCKET_NAME}?scheme=https&endpoint=${R2_ENDPOINT}&region=auto&secret-key=${signing_key_file}" '${{ steps.build-dev-shell.outputs.path }}'
+        nix copy --to "s3://${R2_BUCKET_NAME}?scheme=https&endpoint=${R2_ENDPOINT}&region=auto&profile=default&secret-key=${signing_key_file}" '${{ steps.build-dev-shell.outputs.path }}'
 
     - name: Check cache availability from public domain
       run: |

--- a/.github/workflows/publish-nix-cache.yml
+++ b/.github/workflows/publish-nix-cache.yml
@@ -38,6 +38,11 @@ jobs:
         printf 'path=%s\n' "$(nix build --no-link --print-out-paths .#devShells.x86_64-linux.default)" >> "${GITHUB_OUTPUT}"
 
     - name: Publish dev shell closure to R2 cache
+      env:
+        R2_ACCESS_KEY: ${{ secrets.R2_ACCESS_KEY }}
+        R2_SECRET_KEY: ${{ secrets.R2_SECRET_KEY }}
+        R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+        NIX_CACHE_PRIVATE_KEY: ${{ secrets.NIX_CACHE_PRIVATE_KEY }}
       run: |
         set -euo pipefail
 
@@ -45,8 +50,8 @@ jobs:
         mkdir -p "${aws_dir}"
         {
           printf '%s\n' '[default]'
-          printf '%s\n' "aws_access_key_id=${{ secrets.R2_ACCESS_KEY }}"
-          printf '%s\n' "aws_secret_access_key=${{ secrets.R2_SECRET_KEY }}"
+          printf '%s\n' "aws_access_key_id=${R2_ACCESS_KEY}"
+          printf '%s\n' "aws_secret_access_key=${R2_SECRET_KEY}"
         } > "${aws_dir}/credentials"
         {
           printf '%s\n' '[default]'
@@ -55,10 +60,10 @@ jobs:
         chmod 600 "${aws_dir}/credentials" "${aws_dir}/config"
 
         signing_key_file="${RUNNER_TEMP}/nix-cache-private-key"
-        printf '%s\n' '${{ secrets.NIX_CACHE_PRIVATE_KEY }}' > "${signing_key_file}"
+        printf '%s\n' "${NIX_CACHE_PRIVATE_KEY}" > "${signing_key_file}"
         chmod 600 "${signing_key_file}"
 
-        nix copy --to "s3://${R2_BUCKET_NAME}?endpoint=${{ secrets.R2_ACCOUNT_ID }}.r2.cloudflarestorage.com&profile=default&secret-key=${signing_key_file}" '${{ steps.build-dev-shell.outputs.path }}'
+        nix copy --to "s3://${R2_BUCKET_NAME}?endpoint=${R2_ACCOUNT_ID}.r2.cloudflarestorage.com&profile=default&secret-key=${signing_key_file}" '${{ steps.build-dev-shell.outputs.path }}'
 
     - name: Check cache availability from public domain
       run: |

--- a/.github/workflows/publish-nix-cache.yml
+++ b/.github/workflows/publish-nix-cache.yml
@@ -22,6 +22,7 @@ jobs:
     env:
       R2_BUCKET_NAME: challenges-nix-cache
       R2_PUBLIC_CACHE_DOMAIN: nix-cache.challenges.pwn.college
+      R2_ENDPOINT: https://${{ secrets.R2_ACCOUNT_ID }}.r2.cloudflarestorage.com
     steps:
     - uses: actions/checkout@v4
 
@@ -63,7 +64,7 @@ jobs:
         printf '%s\n' "${NIX_CACHE_PRIVATE_KEY}" > "${signing_key_file}"
         chmod 600 "${signing_key_file}"
 
-        nix copy --to "s3://${R2_BUCKET_NAME}?endpoint=${R2_ACCOUNT_ID}.r2.cloudflarestorage.com&profile=default&secret-key=${signing_key_file}" '${{ steps.build-dev-shell.outputs.path }}'
+        nix copy --to "s3://${R2_BUCKET_NAME}?endpoint=${R2_ENDPOINT}&profile=default&secret-key=${signing_key_file}" '${{ steps.build-dev-shell.outputs.path }}'
 
     - name: Check cache availability from public domain
       run: |

--- a/.github/workflows/publish-nix-cache.yml
+++ b/.github/workflows/publish-nix-cache.yml
@@ -22,7 +22,6 @@ jobs:
     env:
       R2_BUCKET_NAME: challenges-nix-cache
       R2_PUBLIC_CACHE_DOMAIN: nix-cache.challenges.pwn.college
-      R2_ENDPOINT: ${{ secrets.R2_ACCOUNT_ID }}.r2.cloudflarestorage.com
     steps:
     - uses: actions/checkout@v4
 
@@ -39,11 +38,6 @@ jobs:
         printf 'path=%s\n' "$(nix build --no-link --print-out-paths .#devShells.x86_64-linux.default)" >> "${GITHUB_OUTPUT}"
 
     - name: Publish dev shell closure to R2 cache
-      env:
-        AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_KEY }}
-        AWS_EC2_METADATA_DISABLED: "true"
-        NIX_CACHE_PRIVATE_KEY: ${{ secrets.NIX_CACHE_PRIVATE_KEY }}
       run: |
         set -euo pipefail
 
@@ -51,8 +45,8 @@ jobs:
         mkdir -p "${aws_dir}"
         {
           printf '%s\n' '[default]'
-          printf '%s\n' "aws_access_key_id=${AWS_ACCESS_KEY_ID}"
-          printf '%s\n' "aws_secret_access_key=${AWS_SECRET_ACCESS_KEY}"
+          printf '%s\n' "aws_access_key_id=${{ secrets.R2_ACCESS_KEY }}"
+          printf '%s\n' "aws_secret_access_key=${{ secrets.R2_SECRET_KEY }}"
         } > "${aws_dir}/credentials"
         {
           printf '%s\n' '[default]'
@@ -61,10 +55,10 @@ jobs:
         chmod 600 "${aws_dir}/credentials" "${aws_dir}/config"
 
         signing_key_file="${RUNNER_TEMP}/nix-cache-private-key"
-        printf '%s\n' "${NIX_CACHE_PRIVATE_KEY}" > "${signing_key_file}"
+        printf '%s\n' '${{ secrets.NIX_CACHE_PRIVATE_KEY }}' > "${signing_key_file}"
         chmod 600 "${signing_key_file}"
 
-        nix copy --to "s3://${R2_BUCKET_NAME}?scheme=https&endpoint=${R2_ENDPOINT}&region=auto&profile=default&secret-key=${signing_key_file}" '${{ steps.build-dev-shell.outputs.path }}'
+        nix copy --to "s3://${R2_BUCKET_NAME}?endpoint=${{ secrets.R2_ACCOUNT_ID }}.r2.cloudflarestorage.com&profile=default&secret-key=${signing_key_file}" '${{ steps.build-dev-shell.outputs.path }}'
 
     - name: Check cache availability from public domain
       run: |


### PR DESCRIPTION
The publish workflow is failing to access R2 via Nix's `s3://` store.

This change makes AWS credential discovery deterministic by writing:
- `~/.aws/credentials` (from `R2_ACCESS_KEY` / `R2_SECRET_KEY`)
- `~/.aws/config` (sets `region=auto`)

It also forces `profile=default` in the `s3://...` store URL used by `nix copy`.
