### PR TITLE
ci: fix publish nix cache

### DIFF
--- a/.github/workflows/publish-nix-cache.yml
+++ b/.github/workflows/publish-nix-cache.yml
@@ -39,7 +39,7 @@ jobs:
       run: |
         set -euo pipefail
         nix_cache_private_key="${RUNNER_TEMP}/nix-cache-private-key"
-        printf '%s\n' '${{ secrets.NIX_CACHE_PRIVATE_KEY }}' > "${nix_cache_private_key}"
+        echo '${{ secrets.NIX_CACHE_PRIVATE_KEY }}' > "${nix_cache_private_key}"
         chmod 600 "${nix_cache_private_key}"
         nix store sign --recursive --key-file "${nix_cache_private_key}" '${{ steps.build-dev-shell.outputs.path }}'
 

--- a/.github/workflows/publish-nix-cache.yml
+++ b/.github/workflows/publish-nix-cache.yml
@@ -28,6 +28,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: DeterminateSystems/nix-installer-action@main
     - uses: DeterminateSystems/magic-nix-cache-action@main
+
     - name: Build dev shell
       id: build-dev-shell
       run: |
@@ -35,13 +36,10 @@ jobs:
         printf 'path=%s\n' "$(nix build --accept-flake-config --no-link --print-out-paths .#devShells.x86_64-linux.default)" >> "${GITHUB_OUTPUT}"
 
     - name: Sign dev shell closure
-      env:
-        NIX_CACHE_PRIVATE_KEY: ${{ secrets.NIX_CACHE_PRIVATE_KEY }}
       run: |
         set -euo pipefail
         nix_cache_private_key="${RUNNER_TEMP}/nix-cache-private-key"
-        # shellcheck disable=SC2153
-        printf '%s\n' "${NIX_CACHE_PRIVATE_KEY}" > "${nix_cache_private_key}"
+        printf '%s\n' '${{ secrets.NIX_CACHE_PRIVATE_KEY }}' > "${nix_cache_private_key}"
         chmod 600 "${nix_cache_private_key}"
         nix store sign --recursive --key-file "${nix_cache_private_key}" '${{ steps.build-dev-shell.outputs.path }}'
 

--- a/.github/workflows/publish-nix-cache.yml
+++ b/.github/workflows/publish-nix-cache.yml
@@ -28,7 +28,7 @@ jobs:
       id: build-dev-shell
       run: |
         set -euo pipefail
-        printf 'path=%s\n' "$(nix build --accept-flake-config --no-link --print-out-paths .#devShells.x86_64-linux.default)" >> "${GITHUB_OUTPUT}"
+        printf 'path=%s\n' "$(nix build --no-link --print-out-paths .#devShells.x86_64-linux.default)" >> "${GITHUB_OUTPUT}"
 
     - name: Sign dev shell closure
       run: |

--- a/.github/workflows/publish-nix-cache.yml
+++ b/.github/workflows/publish-nix-cache.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Sign dev shell closure
       run: |
         set -euo pipefail
-        nix store sign --recursive --key-file <(printf '%s\n' '${{ secrets.NIX_CACHE_PRIVATE_KEY }}') '${{ steps.build-dev-shell.outputs.path }}'
+        nix store sign --recursive --key-file <(echo '${{ secrets.NIX_CACHE_PRIVATE_KEY }}') '${{ steps.build-dev-shell.outputs.path }}'
 
     - name: Configure AWS credentials
       env:

--- a/.github/workflows/publish-nix-cache.yml
+++ b/.github/workflows/publish-nix-cache.yml
@@ -52,7 +52,7 @@ jobs:
     - name: Publish dev shell closure to R2 cache
       run: |
         set -euo pipefail
-        nix copy --to "s3://${R2_BUCKET_NAME}?profile=${AWS_PROFILE_NAME}&endpoint=${R2_ENDPOINT}&compression=zstd" '${{ steps.build-dev-shell.outputs.path }}'
+        nix copy --to "s3://${R2_BUCKET_NAME}?profile=${AWS_PROFILE_NAME}&endpoint=${R2_ENDPOINT}" '${{ steps.build-dev-shell.outputs.path }}'
 
     - name: Check cache availability from public domain
       run: |

--- a/.github/workflows/publish-nix-cache.yml
+++ b/.github/workflows/publish-nix-cache.yml
@@ -38,10 +38,7 @@ jobs:
     - name: Sign dev shell closure
       run: |
         set -euo pipefail
-        nix_cache_private_key="${RUNNER_TEMP}/nix-cache-private-key"
-        echo '${{ secrets.NIX_CACHE_PRIVATE_KEY }}' > "${nix_cache_private_key}"
-        chmod 600 "${nix_cache_private_key}"
-        nix store sign --recursive --key-file "${nix_cache_private_key}" '${{ steps.build-dev-shell.outputs.path }}'
+        nix store sign --recursive --key-file <(printf '%s\n' '${{ secrets.NIX_CACHE_PRIVATE_KEY }}') '${{ steps.build-dev-shell.outputs.path }}'
 
     - name: Configure AWS credentials
       env:

--- a/.github/workflows/publish-nix-cache.yml
+++ b/.github/workflows/publish-nix-cache.yml
@@ -19,11 +19,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    env:
-      R2_BUCKET_NAME: challenges-nix-cache
-      R2_PUBLIC_CACHE_DOMAIN: nix-cache.challenges.pwn.college
-      R2_ENDPOINT: ${{ secrets.R2_ACCOUNT_ID }}.r2.cloudflarestorage.com
-      AWS_PROFILE_NAME: default
     steps:
     - uses: actions/checkout@v4
     - uses: DeterminateSystems/nix-installer-action@main
@@ -46,15 +41,20 @@ jobs:
         AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_KEY }}
       run: |
         set -euo pipefail
-        nix shell nixpkgs#awscli --command aws configure set aws_access_key_id "${AWS_ACCESS_KEY_ID}" --profile "${AWS_PROFILE_NAME}"
-        nix shell nixpkgs#awscli --command aws configure set aws_secret_access_key "${AWS_SECRET_ACCESS_KEY}" --profile "${AWS_PROFILE_NAME}"
+        nix shell nixpkgs#awscli --command aws configure set aws_access_key_id "${AWS_ACCESS_KEY_ID}"
+        nix shell nixpkgs#awscli --command aws configure set aws_secret_access_key "${AWS_SECRET_ACCESS_KEY}"
 
     - name: Publish dev shell closure to R2 cache
+      env:
+        R2_BUCKET_NAME: challenges-nix-cache
+        R2_ENDPOINT: ${{ secrets.R2_ACCOUNT_ID }}.r2.cloudflarestorage.com
       run: |
         set -euo pipefail
-        nix copy --to "s3://${R2_BUCKET_NAME}?profile=${AWS_PROFILE_NAME}&endpoint=${R2_ENDPOINT}" '${{ steps.build-dev-shell.outputs.path }}'
+        nix copy --to "s3://${R2_BUCKET_NAME}?endpoint=${R2_ENDPOINT}" '${{ steps.build-dev-shell.outputs.path }}'
 
     - name: Check cache availability from public domain
+      env:
+        R2_PUBLIC_CACHE_DOMAIN: nix-cache.challenges.pwn.college
       run: |
         set -euo pipefail
         nix path-info --store "https://${R2_PUBLIC_CACHE_DOMAIN}" '${{ steps.build-dev-shell.outputs.path }}' >/dev/null

--- a/.github/workflows/publish-nix-cache.yml
+++ b/.github/workflows/publish-nix-cache.yml
@@ -22,7 +22,8 @@ jobs:
     env:
       R2_BUCKET_NAME: challenges-nix-cache
       R2_PUBLIC_CACHE_DOMAIN: nix-cache.challenges.pwn.college
-      R2_ENDPOINT: https://${{ secrets.R2_ACCOUNT_ID }}.r2.cloudflarestorage.com
+      R2_ENDPOINT: ${{ secrets.R2_ACCOUNT_ID }}.r2.cloudflarestorage.com
+      AWS_PROFILE_NAME: default
     steps:
     - uses: actions/checkout@v4
     - uses: DeterminateSystems/nix-installer-action@main
@@ -31,35 +32,32 @@ jobs:
       id: build-dev-shell
       run: |
         set -euo pipefail
-        printf 'path=%s\n' "$(nix build --no-link --print-out-paths .#devShells.x86_64-linux.default)" >> "${GITHUB_OUTPUT}"
+        printf 'path=%s\n' "$(nix build --accept-flake-config --no-link --print-out-paths .#devShells.x86_64-linux.default)" >> "${GITHUB_OUTPUT}"
 
-    - name: Publish dev shell closure to R2 cache
+    - name: Sign dev shell closure
       env:
-        R2_ACCESS_KEY: ${{ secrets.R2_ACCESS_KEY }}
-        R2_SECRET_KEY: ${{ secrets.R2_SECRET_KEY }}
-        R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
         NIX_CACHE_PRIVATE_KEY: ${{ secrets.NIX_CACHE_PRIVATE_KEY }}
       run: |
         set -euo pipefail
+        nix_cache_private_key="${RUNNER_TEMP}/nix-cache-private-key"
+        # shellcheck disable=SC2153
+        printf '%s\n' "${NIX_CACHE_PRIVATE_KEY}" > "${nix_cache_private_key}"
+        chmod 600 "${nix_cache_private_key}"
+        nix store sign --recursive --key-file "${nix_cache_private_key}" '${{ steps.build-dev-shell.outputs.path }}'
 
-        aws_dir="${HOME}/.aws"
-        mkdir -p "${aws_dir}"
-        {
-          printf '%s\n' '[default]'
-          printf '%s\n' "aws_access_key_id=${R2_ACCESS_KEY}"
-          printf '%s\n' "aws_secret_access_key=${R2_SECRET_KEY}"
-        } > "${aws_dir}/credentials"
-        {
-          printf '%s\n' '[default]'
-          printf '%s\n' 'region = auto'
-        } > "${aws_dir}/config"
-        chmod 600 "${aws_dir}/credentials" "${aws_dir}/config"
+    - name: Configure AWS credentials
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_KEY }}
+      run: |
+        set -euo pipefail
+        nix shell nixpkgs#awscli --command aws configure set aws_access_key_id "${AWS_ACCESS_KEY_ID}" --profile "${AWS_PROFILE_NAME}"
+        nix shell nixpkgs#awscli --command aws configure set aws_secret_access_key "${AWS_SECRET_ACCESS_KEY}" --profile "${AWS_PROFILE_NAME}"
 
-        signing_key_file="${RUNNER_TEMP}/nix-cache-private-key"
-        printf '%s\n' "${NIX_CACHE_PRIVATE_KEY}" > "${signing_key_file}"
-        chmod 600 "${signing_key_file}"
-
-        nix copy --to "s3://${R2_BUCKET_NAME}?endpoint=${R2_ENDPOINT}&profile=default&secret-key=${signing_key_file}" '${{ steps.build-dev-shell.outputs.path }}'
+    - name: Publish dev shell closure to R2 cache
+      run: |
+        set -euo pipefail
+        nix copy --to "s3://${R2_BUCKET_NAME}?profile=${AWS_PROFILE_NAME}&endpoint=${R2_ENDPOINT}&compression=zstd" '${{ steps.build-dev-shell.outputs.path }}'
 
     - name: Check cache availability from public domain
       run: |


### PR DESCRIPTION
## Summary
- switch publish workflow to the explicit build/sign/configure/copy flow
- build dev shell with `nix build --accept-flake-config`
- sign the dev shell closure via `nix store sign --recursive`
- configure AWS profile credentials via `aws configure set` using `nix shell nixpkgs#awscli`
- publish to R2 with `nix copy` using `profile`, `endpoint`, and `compression=zstd`

## Validation
- actionlint passes for `.github/workflows/publish-nix-cache.yml`
- local dry run of the same flow against R2 completed without 403