### PR TITLE
ci: downgrade determinate nix action

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: DeterminateSystems/determinate-nix-action@v3.14.0
-    - uses: DeterminateSystems/magic-nix-cache-action@main
+    - uses: DeterminateSystems/flakehub-cache-action@v3.15.2
     - name: nix fmt (must be clean)
       run: |
         set -euo pipefail

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: DeterminateSystems/nix-installer-action@main
+    - uses: DeterminateSystems/determinate-nix-action@v3.14.0
     - uses: DeterminateSystems/magic-nix-cache-action@main
     - name: nix fmt (must be clean)
       run: |

--- a/.github/workflows/publish-nix-cache.yml
+++ b/.github/workflows/publish-nix-cache.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: DeterminateSystems/determinate-nix-action@v3.14.0
-    - uses: DeterminateSystems/magic-nix-cache-action@main
+    - uses: DeterminateSystems/flakehub-cache-action@v3.15.2
 
     - name: Build dev shell
       id: build-dev-shell

--- a/.github/workflows/publish-nix-cache.yml
+++ b/.github/workflows/publish-nix-cache.yml
@@ -21,7 +21,7 @@ jobs:
       contents: read
     steps:
     - uses: actions/checkout@v4
-    - uses: DeterminateSystems/nix-installer-action@main
+    - uses: DeterminateSystems/determinate-nix-action@v3.14.0
     - uses: DeterminateSystems/magic-nix-cache-action@main
 
     - name: Build dev shell
@@ -43,6 +43,7 @@ jobs:
         set -euo pipefail
         nix shell nixpkgs#awscli --command aws configure set aws_access_key_id "${AWS_ACCESS_KEY_ID}"
         nix shell nixpkgs#awscli --command aws configure set aws_secret_access_key "${AWS_SECRET_ACCESS_KEY}"
+        nix shell nixpkgs#awscli --command aws configure set region auto
 
     - name: Publish dev shell closure to R2 cache
       env:


### PR DESCRIPTION
There is a regression in the current version of nix that breaks `nix copy`.

See:
- https://github.com/NixOS/nix/issues/15019
- https://github.com/bureau-foundation/bureau/issues/15

When the version bumps, we can upgrade.