### PR TITLE
ci: configure nix substituters

### DIFF
--- a/.github/actions/setup-nix/action.yml
+++ b/.github/actions/setup-nix/action.yml
@@ -1,0 +1,12 @@
+name: Setup nix
+description: Install Nix and configure binary caches for this repo.
+runs:
+  using: composite
+  steps:
+    - uses: DeterminateSystems/determinate-nix-action@v3.14.0
+      with:
+        extra-conf: |
+          extra-substituters = https://nix-cache.challenges.pwn.college
+          extra-trusted-public-keys = nix-cache.challenges.pwn.college-1:Qj32MyanSS2fW+W7MtEFN3fWSksMT8l6IyJuG9Lw5bc=
+    - uses: DeterminateSystems/flakehub-cache-action@v3.15.2
+

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -11,12 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: DeterminateSystems/determinate-nix-action@v3.14.0
-      with:
-        extra-conf: |
-          extra-substituters = https://nix-cache.challenges.pwn.college
-          extra-trusted-public-keys = nix-cache.challenges.pwn.college-1:Qj32MyanSS2fW+W7MtEFN3fWSksMT8l6IyJuG9Lw5bc=
-    - uses: DeterminateSystems/flakehub-cache-action@v3.15.2
+    - uses: ./.github/actions/setup-nix
     - name: nix fmt (must be clean)
       run: |
         set -euo pipefail

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -12,6 +12,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: DeterminateSystems/determinate-nix-action@v3.14.0
+      with:
+        extra-conf: |
+          extra-substituters = https://nix-cache.challenges.pwn.college
+          extra-trusted-public-keys = nix-cache.challenges.pwn.college-1:Qj32MyanSS2fW+W7MtEFN3fWSksMT8l6IyJuG9Lw5bc=
     - uses: DeterminateSystems/flakehub-cache-action@v3.15.2
     - name: nix fmt (must be clean)
       run: |

--- a/.github/workflows/publish-challenges.yml
+++ b/.github/workflows/publish-challenges.yml
@@ -34,6 +34,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: DeterminateSystems/determinate-nix-action@v3.14.0
+      with:
+        extra-conf: |
+          extra-substituters = https://nix-cache.challenges.pwn.college
+          extra-trusted-public-keys = nix-cache.challenges.pwn.college-1:Qj32MyanSS2fW+W7MtEFN3fWSksMT8l6IyJuG9Lw5bc=
     - uses: DeterminateSystems/flakehub-cache-action@v3.15.2
     - uses: ./.github/actions/setup-challenge-runtime
 

--- a/.github/workflows/publish-challenges.yml
+++ b/.github/workflows/publish-challenges.yml
@@ -33,12 +33,7 @@ jobs:
         challenges: ${{ fromJson(needs.determine-modified-challenges.outputs.challenges) }}
     steps:
     - uses: actions/checkout@v4
-    - uses: DeterminateSystems/determinate-nix-action@v3.14.0
-      with:
-        extra-conf: |
-          extra-substituters = https://nix-cache.challenges.pwn.college
-          extra-trusted-public-keys = nix-cache.challenges.pwn.college-1:Qj32MyanSS2fW+W7MtEFN3fWSksMT8l6IyJuG9Lw5bc=
-    - uses: DeterminateSystems/flakehub-cache-action@v3.15.2
+    - uses: ./.github/actions/setup-nix
     - uses: ./.github/actions/setup-challenge-runtime
 
     - name: Install uv

--- a/.github/workflows/publish-nix-cache.yml
+++ b/.github/workflows/publish-nix-cache.yml
@@ -21,12 +21,7 @@ jobs:
       contents: read
     steps:
     - uses: actions/checkout@v4
-    - uses: DeterminateSystems/determinate-nix-action@v3.14.0
-      with:
-        extra-conf: |
-          extra-substituters = https://nix-cache.challenges.pwn.college
-          extra-trusted-public-keys = nix-cache.challenges.pwn.college-1:Qj32MyanSS2fW+W7MtEFN3fWSksMT8l6IyJuG9Lw5bc=
-    - uses: DeterminateSystems/flakehub-cache-action@v3.15.2
+    - uses: ./.github/actions/setup-nix
 
     - name: Build dev shell
       id: build-dev-shell

--- a/.github/workflows/publish-nix-cache.yml
+++ b/.github/workflows/publish-nix-cache.yml
@@ -22,6 +22,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: DeterminateSystems/determinate-nix-action@v3.14.0
+      with:
+        extra-conf: |
+          extra-substituters = https://nix-cache.challenges.pwn.college
+          extra-trusted-public-keys = nix-cache.challenges.pwn.college-1:Qj32MyanSS2fW+W7MtEFN3fWSksMT8l6IyJuG9Lw5bc=
     - uses: DeterminateSystems/flakehub-cache-action@v3.15.2
 
     - name: Build dev shell

--- a/.github/workflows/test-challenges.yml
+++ b/.github/workflows/test-challenges.yml
@@ -37,12 +37,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - uses: DeterminateSystems/determinate-nix-action@v3.14.0
-      with:
-        extra-conf: |
-          extra-substituters = https://nix-cache.challenges.pwn.college
-          extra-trusted-public-keys = nix-cache.challenges.pwn.college-1:Qj32MyanSS2fW+W7MtEFN3fWSksMT8l6IyJuG9Lw5bc=
-    - uses: DeterminateSystems/flakehub-cache-action@v3.15.2
+    - uses: ./.github/actions/setup-nix
     - uses: ./.github/actions/setup-challenge-runtime
 
     - name: Test challenges

--- a/.github/workflows/test-challenges.yml
+++ b/.github/workflows/test-challenges.yml
@@ -38,6 +38,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: DeterminateSystems/determinate-nix-action@v3.14.0
+      with:
+        extra-conf: |
+          extra-substituters = https://nix-cache.challenges.pwn.college
+          extra-trusted-public-keys = nix-cache.challenges.pwn.college-1:Qj32MyanSS2fW+W7MtEFN3fWSksMT8l6IyJuG9Lw5bc=
     - uses: DeterminateSystems/flakehub-cache-action@v3.15.2
     - uses: ./.github/actions/setup-challenge-runtime
 


### PR DESCRIPTION
Configure DeterminateSystems/determinate-nix-action with extra-conf so Nix uses the challenges cache without relying on flake nixConfig.

Applied to every workflow using determinate-nix-action.

extra-substituters:
- https://nix-cache.challenges.pwn.college

extra-trusted-public-keys:
- nix-cache.challenges.pwn.college-1:Qj32MyanSS2fW+W7MtEFN3fWSksMT8l6IyJuG9Lw5bc=
