### PR TITLE
ci: install python3-dev so uv can build pyastyle

### DIFF
--- a/.github/actions/determine-modified-challenges/action.yml
+++ b/.github/actions/determine-modified-challenges/action.yml
@@ -39,6 +39,13 @@ runs:
       with:
         fetch-depth: 0
 
+    - name: Install Python headers for native wheels
+      shell: bash
+      run: |
+        set -euo pipefail
+        sudo apt-get update
+        sudo apt-get install -y python3-dev
+
     - name: Install uv
       uses: astral-sh/setup-uv@v7
       with:

--- a/.github/actions/test-challenges/action.yml
+++ b/.github/actions/test-challenges/action.yml
@@ -16,6 +16,13 @@ runs:
       with:
         fetch-depth: 0
 
+    - name: Install Python headers for native wheels
+      shell: bash
+      run: |
+        set -euo pipefail
+        sudo apt-get update
+        sudo apt-get install -y python3-dev
+
     - name: Remove encrypted directories
       shell: 'nix develop -c bash -euo pipefail {0}'
       run: |


### PR DESCRIPTION
Fixes CI failure when uv builds pyastyle on ubuntu-latest (missing x86_64-linux-gnu/python*/pyconfig.h).

Adds python3-dev installation before running pwnshop via uv in:
- .github/actions/determine-modified-challenges
- .github/actions/test-challenges
