### PR TITLE
pwnshop: format .c templates with clang-format

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -56,6 +56,9 @@
             text = ''
               set -euo pipefail
               root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+              # On NixOS, the PyPI clang-format wheel's embedded binary generally can't run
+              # (dynamic linker), so force the Nix-provided clang-format.
+              export PWN_CLANG_FORMAT='${pkgs.clang-tools}/bin/clang-format'
               exec "$root/pwnshop" "$@"
             '';
           };
@@ -73,6 +76,8 @@
             ];
             shellHook = ''
               export DOCKER_HOST="$(sudo ${pwn-challenge-runtime}/bin/pwn-challenge-runtime)"
+              # Ensure pwnshop uses a working clang-format under Nix (uv's wheel binary won't).
+              export PWN_CLANG_FORMAT='${pkgs.clang-tools}/bin/clang-format'
             '';
           };
         }

--- a/flake.nix
+++ b/flake.nix
@@ -49,6 +49,7 @@
           pwnshop = pkgs.writeShellApplication {
             name = "pwnshop";
             runtimeInputs = with pkgs; [
+              clang-tools
               git
               uv
             ];
@@ -62,6 +63,7 @@
         {
           default = pkgs.mkShell {
             packages = with pkgs; [
+              clang-tools
               docker
               git
               git-crypt

--- a/flake.nix
+++ b/flake.nix
@@ -49,7 +49,6 @@
           pwnshop = pkgs.writeShellApplication {
             name = "pwnshop";
             runtimeInputs = with pkgs; [
-              clang-tools
               git
               uv
             ];
@@ -63,7 +62,6 @@
         {
           default = pkgs.mkShell {
             packages = with pkgs; [
-              clang-tools
               docker
               git
               git-crypt

--- a/flake.nix
+++ b/flake.nix
@@ -56,9 +56,6 @@
             text = ''
               set -euo pipefail
               root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
-              # On NixOS, the PyPI clang-format wheel's embedded binary generally can't run
-              # (dynamic linker), so force the Nix-provided clang-format.
-              export PWN_CLANG_FORMAT='${pkgs.clang-tools}/bin/clang-format'
               exec "$root/pwnshop" "$@"
             '';
           };
@@ -76,8 +73,6 @@
             ];
             shellHook = ''
               export DOCKER_HOST="$(sudo ${pwn-challenge-runtime}/bin/pwn-challenge-runtime)"
-              # Ensure pwnshop uses a working clang-format under Nix (uv's wheel binary won't).
-              export PWN_CLANG_FORMAT='${pkgs.clang-tools}/bin/clang-format'
             '';
           };
         }

--- a/flake.nix
+++ b/flake.nix
@@ -62,6 +62,7 @@
         {
           default = pkgs.mkShell {
             packages = with pkgs; [
+              clang-tools
               docker
               git
               git-crypt

--- a/tools/pwnshop/pyproject.toml
+++ b/tools/pwnshop/pyproject.toml
@@ -8,7 +8,6 @@ dependencies = [
   "black",
   "click",
   "jinja2",
-  "pyastyle",
   "rich",
 ]
 

--- a/tools/pwnshop/pyproject.toml
+++ b/tools/pwnshop/pyproject.toml
@@ -7,8 +7,8 @@ authors = [{ name = "pwn.college" }]
 dependencies = [
   "black",
   "click",
-  "clang-format",
   "jinja2",
+  "pyastyle",
   "rich",
 ]
 

--- a/tools/pwnshop/pyproject.toml
+++ b/tools/pwnshop/pyproject.toml
@@ -7,8 +7,8 @@ authors = [{ name = "pwn.college" }]
 dependencies = [
   "black",
   "click",
+  "clang-format",
   "jinja2",
-  "pyastyle",
   "rich",
 ]
 

--- a/tools/pwnshop/src/pwnshop/lib/__init__.py
+++ b/tools/pwnshop/src/pwnshop/lib/__init__.py
@@ -99,8 +99,8 @@ def render(template: pathlib.Path) -> str:
             logger.debug("formatting %s as python with black", template)
             return black.format_str(rendered, mode=black.FileMode(line_length=120))
         if ".c" in template.suffixes:
-            logger.debug("formatting %s as C with astyle", template)
-            return re.sub("\n{2,}", "\n\n", pyastyle.format(rendered, "--style=allman"))
+            logger.debug("formatting %s as C with clang-format", template)
+            return subprocess.check_output(["clang-format", "-style={BasedOnStyle: LLVM, BreakBeforeBraces: Allman, ColumnLimit: 120}"], input=rendered, text=True)
     except black.parsing.InvalidInput as error:
         logger.warning("template %s does not format properly: %s", template, error)
     return rendered

--- a/tools/pwnshop/src/pwnshop/lib/__init__.py
+++ b/tools/pwnshop/src/pwnshop/lib/__init__.py
@@ -12,7 +12,6 @@ from typing import Iterable, Iterator, List, Optional, Sequence
 
 import black
 import jinja2
-import pyastyle
 
 logger = logging.getLogger(__name__)
 

--- a/tools/pwnshop/src/pwnshop/lib/__init__.py
+++ b/tools/pwnshop/src/pwnshop/lib/__init__.py
@@ -16,6 +16,7 @@ import jinja2
 logger = logging.getLogger(__name__)
 
 CHALLENGE_SEED = int(os.environ.get("CHALLENGE_SEED", "0"))
+
 clang_format = shutil.which("clang-format")
 if not clang_format:
     logger.warning("clang-format not found; C templates will not be formatted")

--- a/tools/pwnshop/src/pwnshop/lib/__init__.py
+++ b/tools/pwnshop/src/pwnshop/lib/__init__.py
@@ -100,7 +100,7 @@ def render(template: pathlib.Path) -> str:
             return black.format_str(rendered, mode=black.FileMode(line_length=120))
         if ".c" in template.suffixes:
             logger.debug("formatting %s as C with clang-format", template)
-            return subprocess.check_output(["clang-format", "-style={BasedOnStyle: LLVM, BreakBeforeBraces: Allman, ColumnLimit: 120}"], input=rendered, text=True)
+            return subprocess.check_output(["clang-format"], input=rendered, text=True)
     except black.parsing.InvalidInput as error:
         logger.warning("template %s does not format properly: %s", template, error)
     return rendered

--- a/tools/pwnshop/src/pwnshop/lib/__init__.py
+++ b/tools/pwnshop/src/pwnshop/lib/__init__.py
@@ -7,12 +7,12 @@ import random
 import re
 import shutil
 import subprocess
-import sys
 import tempfile
 from typing import Iterable, Iterator, List, Optional, Sequence
 
 import black
 import jinja2
+import pyastyle
 
 logger = logging.getLogger(__name__)
 
@@ -84,49 +84,6 @@ class _NoSelfExtendEnv(jinja2.Environment):
         return template
 
 
-def _clang_format(contents: str, *, assume_filename: str) -> str:
-    override = os.environ.get("PWN_CLANG_FORMAT")
-    if override:
-        clang_format = override
-    elif os.environ.get("IN_NIX_SHELL"):
-        # When running under Nix, prefer the Nix-provided clang-format (in /nix/store)
-        # over any venv-provided wrapper. On NixOS, binaries from manylinux wheels
-        # typically won't run without nix-ld.
-        clang_format = _which_ignoring_prefix("clang-format", ignore_prefix=sys.prefix)
-    else:
-        clang_format = shutil.which("clang-format")
-
-    if not clang_format:
-        raise FileNotFoundError("clang-format not found in PATH (set PWN_CLANG_FORMAT to override)")
-
-    # Keep this self-contained (no repo-wide .clang-format dependency) and roughly
-    # match the previous astyle Allman output.
-    style = "{BasedOnStyle: LLVM, BreakBeforeBraces: Allman, ColumnLimit: 120}"
-    proc = subprocess.run(
-        [clang_format, f"-assume-filename={assume_filename}", f"-style={style}"],
-        input=contents,
-        text=True,
-        capture_output=True,
-        check=True,
-    )
-    return proc.stdout
-
-
-def _which_ignoring_prefix(exe: str, *, ignore_prefix: str) -> Optional[str]:
-    ignore_prefix_real = os.path.realpath(ignore_prefix)
-    for directory in os.environ.get("PATH", "").split(os.pathsep):
-        if not directory:
-            continue
-        candidate = os.path.join(directory, exe)
-        if not (os.path.isfile(candidate) and os.access(candidate, os.X_OK)):
-            continue
-        candidate_real = os.path.realpath(candidate)
-        if candidate_real == ignore_prefix_real or candidate_real.startswith(ignore_prefix_real + os.sep):
-            continue
-        return candidate
-    return None
-
-
 def render(template: pathlib.Path) -> str:
     logger.debug("rendering template %s (seed=%d)", template, CHALLENGE_SEED)
     env = _NoSelfExtendEnv(loader=_NoSelfExtendLoader(template.parents))
@@ -141,13 +98,10 @@ def render(template: pathlib.Path) -> str:
         if ".py" in template.suffixes or "python" in rendered.splitlines()[0]:
             logger.debug("formatting %s as python with black", template)
             return black.format_str(rendered, mode=black.FileMode(line_length=120))
-        if any(suffix in template.suffixes for suffix in (".c", ".h", ".cc", ".cpp", ".cxx", ".hh", ".hpp")):
-            logger.debug("formatting %s as C/C++ with clang-format", template)
-            assume_filename = template.with_suffix("").name  # strip trailing .j2
-            return re.sub("\n{2,}", "\n\n", _clang_format(rendered, assume_filename=assume_filename))
+        if ".c" in template.suffixes:
+            logger.debug("formatting %s as C with astyle", template)
+            return re.sub("\n{2,}", "\n\n", pyastyle.format(rendered, "--style=allman"))
     except black.parsing.InvalidInput as error:
-        logger.warning("template %s does not format properly: %s", template, error)
-    except (FileNotFoundError, subprocess.CalledProcessError) as error:
         logger.warning("template %s does not format properly: %s", template, error)
     return rendered
 

--- a/tools/pwnshop/src/pwnshop/lib/__init__.py
+++ b/tools/pwnshop/src/pwnshop/lib/__init__.py
@@ -16,6 +16,9 @@ import jinja2
 logger = logging.getLogger(__name__)
 
 CHALLENGE_SEED = int(os.environ.get("CHALLENGE_SEED", "0"))
+clang_format = shutil.which("clang-format")
+if not clang_format:
+    logger.warning("clang-format not found; C templates will not be formatted")
 
 
 class _NoSelfExtendLoader(jinja2.FileSystemLoader):
@@ -97,9 +100,9 @@ def render(template: pathlib.Path) -> str:
         if ".py" in template.suffixes or "python" in rendered.splitlines()[0]:
             logger.debug("formatting %s as python with black", template)
             return black.format_str(rendered, mode=black.FileMode(line_length=120))
-        if ".c" in template.suffixes:
+        if ".c" in template.suffixes and clang_format:
             logger.debug("formatting %s as C with clang-format", template)
-            return subprocess.check_output(["clang-format"], input=rendered, text=True)
+            return subprocess.check_output([clang_format], input=rendered, text=True)
     except black.parsing.InvalidInput as error:
         logger.warning("template %s does not format properly: %s", template, error)
     return rendered

--- a/tools/pwnshop/uv.lock
+++ b/tools/pwnshop/uv.lock
@@ -297,7 +297,6 @@ dependencies = [
     { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "click", version = "8.3.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "jinja2" },
-    { name = "pyastyle" },
     { name = "rich" },
 ]
 
@@ -306,15 +305,8 @@ requires-dist = [
     { name = "black" },
     { name = "click" },
     { name = "jinja2" },
-    { name = "pyastyle" },
     { name = "rich" },
 ]
-
-[[package]]
-name = "pyastyle"
-version = "1.1.5"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/99/b1/c5f00383ef9d2dda1cecace84d152686442dd4c4ae97d1c4a3b83436f653/pyastyle-1.1.5.zip", hash = "sha256:89d6f0432cbc920e6649d9d7a50ba632c8305b28e07c9a9cf4346ef1b00369e3", size = 343648, upload-time = "2015-02-23T10:57:17.992Z" }
 
 [[package]]
 name = "pygments"

--- a/tools/pwnshop/uv.lock
+++ b/tools/pwnshop/uv.lock
@@ -52,31 +52,6 @@ wheels = [
 ]
 
 [[package]]
-name = "clang-format"
-version = "21.1.8"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/29/ed/019e682e9f8a5a5abf4258b293453092ef9524b540ada591ccfdff1246df/clang_format-21.1.8.tar.gz", hash = "sha256:99369fe76526ba6be6d7a8093fee6cd266bbf5ce72597a0d79a4ce9a625b28cf", size = 11509, upload-time = "2025-12-16T20:34:33.065Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/17/1d/4b1d85acb99a2ee3bad0b20cc3e82c58fbfb39bf4dd5856ac1f2c4f36e65/clang_format-21.1.8-py2.py3-none-macosx_10_9_x86_64.whl", hash = "sha256:f447091c346027a09728a0a96128fe058419fe06cf200ccc3dc98bcd4399e351", size = 1465604, upload-time = "2025-12-16T20:34:03.955Z" },
-    { url = "https://files.pythonhosted.org/packages/84/38/a61466227a8a6bf22c583f7bd810e75c9a356cfc63c6a712a201103a4ad3/clang_format-21.1.8-py2.py3-none-macosx_11_0_arm64.whl", hash = "sha256:9a78fabba6b382866819b42a7b220d235a3baf6128a40fb7bd590c037f69879b", size = 1459014, upload-time = "2025-12-16T20:34:05.929Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/5d/6720c895c5cfc01831fac55ecf849f10d03d6222700909af14f6047c933b/clang_format-21.1.8-py2.py3-none-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c2a044953efab5f7d0261f3a76aabc01358592faac1b73af38d8c83db6e91a69", size = 1725482, upload-time = "2025-12-16T20:34:07.525Z" },
-    { url = "https://files.pythonhosted.org/packages/54/0d/074b940884ced1b5c93e2e7fc8a941673519a938e7f31aeade321e3ab094/clang_format-21.1.8-py2.py3-none-manylinux_2_26_i686.manylinux_2_28_i686.whl", hash = "sha256:143d2dffa71058d05ac5ad71321682e23d638bce22c8f2e3d01ed457d841a5f3", size = 1856680, upload-time = "2025-12-16T20:34:09.987Z" },
-    { url = "https://files.pythonhosted.org/packages/34/d5/46e22ae8c4385a7836db7403ced63ea8056c971cbb806bf0c6f0d2133acc/clang_format-21.1.8-py2.py3-none-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:6a4b61a743dad5afc5e60be0c5c8f162f6cf27fff9eed56ec0bf65c2bcbd8a8d", size = 2031282, upload-time = "2025-12-16T20:34:11.565Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/2a/cad75567c312d945cc26aaee7e1b7135703fed9c7e7ad15c427bf6ad7a84/clang_format-21.1.8-py2.py3-none-manylinux_2_26_s390x.manylinux_2_28_s390x.whl", hash = "sha256:94de66c5eeca1270825348687d384750d91f1d8d12216b2df0aea892859be33a", size = 2047763, upload-time = "2025-12-16T20:34:13.175Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/c2/403e7371b1ab0f6175d708ecc93cf18085ea9f903e8fe7d17c43df698f06/clang_format-21.1.8-py2.py3-none-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d12b864b596b80810cdd7f97556c485dc09cfe2952503958535f01359e025fbb", size = 1804755, upload-time = "2025-12-16T20:34:14.813Z" },
-    { url = "https://files.pythonhosted.org/packages/76/33/9e7db5fc4abefb25022d266957f666bfc263ae3e51abdd2c997d2880ceee/clang_format-21.1.8-py2.py3-none-manylinux_2_31_armv7l.whl", hash = "sha256:b81f1e909f5e7ef862a7818dc22b302a3ff407f3534e3395aa7ba26746cc890e", size = 1643208, upload-time = "2025-12-16T20:34:16.898Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/9f/43f4e384cb8943418f94943f682835f375f15b9cc64c526d73a7360f2b2f/clang_format-21.1.8-py2.py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:e10a5dca18a04997ad55c082bc0759edc7e337b24a2373ded109634fde12662a", size = 2701696, upload-time = "2025-12-16T20:34:19.043Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/6a/378187d72a465cebd3dbf7cd455e33b4931daa33e815b7865e6e65591a72/clang_format-21.1.8-py2.py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:10f7d7004d70b5e03fd3f764fc19fae89cd38d68b3482162cb09cac47c12c7b0", size = 2481266, upload-time = "2025-12-16T20:34:20.336Z" },
-    { url = "https://files.pythonhosted.org/packages/99/eb/2332edb1846d6832932191a590203a53ec69f585e718b51796335a1dcb6e/clang_format-21.1.8-py2.py3-none-musllinux_1_2_i686.whl", hash = "sha256:303d5fd53090422119136b1a458e98db429dedd5db0add50e70f885f8c95d82a", size = 2954000, upload-time = "2025-12-16T20:34:21.739Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/b5/eed5c95521b77d3cde024c3a23c7a80c46e78aa5b5a81c5cf935e7267588/clang_format-21.1.8-py2.py3-none-musllinux_1_2_ppc64le.whl", hash = "sha256:6b9e0b45cfaf4a18336a6db4666dd6a6aae840e38b038e6d568a65f43ade007c", size = 3076720, upload-time = "2025-12-16T20:34:23.139Z" },
-    { url = "https://files.pythonhosted.org/packages/14/55/7527fbe31423a1bb53653c2a2b20aa34a73ec33b99199bceaec0f5907295/clang_format-21.1.8-py2.py3-none-musllinux_1_2_s390x.whl", hash = "sha256:4dd0fee9eaee9915ba7fa08e60ee9ddfba1f754d10d71164482d9eb387c431f0", size = 3160892, upload-time = "2025-12-16T20:34:24.618Z" },
-    { url = "https://files.pythonhosted.org/packages/53/61/1623382bc78ef139c196473a5c76b840a071c9002cb5cd2694ac50327db9/clang_format-21.1.8-py2.py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:9731aecf954651004f184347d0c589d4e91a39ccda21262ee17c60f80a4408b2", size = 2812487, upload-time = "2025-12-16T20:34:26.505Z" },
-    { url = "https://files.pythonhosted.org/packages/53/e1/74f2000d44e4904472e5685afb98d19566c515026214733f02bbdc73d6d8/clang_format-21.1.8-py2.py3-none-win32.whl", hash = "sha256:2f5883ca83f718d8c2272e98b3cbda422fec520824b5a1e335c631dc6d812da7", size = 1271310, upload-time = "2025-12-16T20:34:28.179Z" },
-    { url = "https://files.pythonhosted.org/packages/69/7a/c49c8af9135c6a6dfb9cd103328ba7b6551643dce71b57e58ea940884015/clang_format-21.1.8-py2.py3-none-win_amd64.whl", hash = "sha256:a7606da55e31ebf5b63dd75800392e6cca7c595a74100c2cebcda2d742130732", size = 1426467, upload-time = "2025-12-16T20:34:29.805Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/d3/8790b539afb6cb0d4474705d3750e78a1f0847ab6d3ef1b00dd1ae52f364/clang_format-21.1.8-py2.py3-none-win_arm64.whl", hash = "sha256:1aa10b3f647268361d08bf4f17ce70964b8d9c04d5539e7d8acbebd14dc4a49c", size = 1327254, upload-time = "2025-12-16T20:34:31.579Z" },
-]
-
-[[package]]
 name = "click"
 version = "8.1.8"
 source = { registry = "https://pypi.org/simple" }
@@ -319,21 +294,27 @@ version = "0.0.0"
 source = { virtual = "." }
 dependencies = [
     { name = "black" },
-    { name = "clang-format" },
     { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "click", version = "8.3.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "jinja2" },
+    { name = "pyastyle" },
     { name = "rich" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "black" },
-    { name = "clang-format" },
     { name = "click" },
     { name = "jinja2" },
+    { name = "pyastyle" },
     { name = "rich" },
 ]
+
+[[package]]
+name = "pyastyle"
+version = "1.1.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/99/b1/c5f00383ef9d2dda1cecace84d152686442dd4c4ae97d1c4a3b83436f653/pyastyle-1.1.5.zip", hash = "sha256:89d6f0432cbc920e6649d9d7a50ba632c8305b28e07c9a9cf4346ef1b00369e3", size = 343648, upload-time = "2015-02-23T10:57:17.992Z" }
 
 [[package]]
 name = "pygments"

--- a/tools/pwnshop/uv.lock
+++ b/tools/pwnshop/uv.lock
@@ -52,6 +52,31 @@ wheels = [
 ]
 
 [[package]]
+name = "clang-format"
+version = "21.1.8"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/29/ed/019e682e9f8a5a5abf4258b293453092ef9524b540ada591ccfdff1246df/clang_format-21.1.8.tar.gz", hash = "sha256:99369fe76526ba6be6d7a8093fee6cd266bbf5ce72597a0d79a4ce9a625b28cf", size = 11509, upload-time = "2025-12-16T20:34:33.065Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/17/1d/4b1d85acb99a2ee3bad0b20cc3e82c58fbfb39bf4dd5856ac1f2c4f36e65/clang_format-21.1.8-py2.py3-none-macosx_10_9_x86_64.whl", hash = "sha256:f447091c346027a09728a0a96128fe058419fe06cf200ccc3dc98bcd4399e351", size = 1465604, upload-time = "2025-12-16T20:34:03.955Z" },
+    { url = "https://files.pythonhosted.org/packages/84/38/a61466227a8a6bf22c583f7bd810e75c9a356cfc63c6a712a201103a4ad3/clang_format-21.1.8-py2.py3-none-macosx_11_0_arm64.whl", hash = "sha256:9a78fabba6b382866819b42a7b220d235a3baf6128a40fb7bd590c037f69879b", size = 1459014, upload-time = "2025-12-16T20:34:05.929Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/5d/6720c895c5cfc01831fac55ecf849f10d03d6222700909af14f6047c933b/clang_format-21.1.8-py2.py3-none-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c2a044953efab5f7d0261f3a76aabc01358592faac1b73af38d8c83db6e91a69", size = 1725482, upload-time = "2025-12-16T20:34:07.525Z" },
+    { url = "https://files.pythonhosted.org/packages/54/0d/074b940884ced1b5c93e2e7fc8a941673519a938e7f31aeade321e3ab094/clang_format-21.1.8-py2.py3-none-manylinux_2_26_i686.manylinux_2_28_i686.whl", hash = "sha256:143d2dffa71058d05ac5ad71321682e23d638bce22c8f2e3d01ed457d841a5f3", size = 1856680, upload-time = "2025-12-16T20:34:09.987Z" },
+    { url = "https://files.pythonhosted.org/packages/34/d5/46e22ae8c4385a7836db7403ced63ea8056c971cbb806bf0c6f0d2133acc/clang_format-21.1.8-py2.py3-none-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:6a4b61a743dad5afc5e60be0c5c8f162f6cf27fff9eed56ec0bf65c2bcbd8a8d", size = 2031282, upload-time = "2025-12-16T20:34:11.565Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/2a/cad75567c312d945cc26aaee7e1b7135703fed9c7e7ad15c427bf6ad7a84/clang_format-21.1.8-py2.py3-none-manylinux_2_26_s390x.manylinux_2_28_s390x.whl", hash = "sha256:94de66c5eeca1270825348687d384750d91f1d8d12216b2df0aea892859be33a", size = 2047763, upload-time = "2025-12-16T20:34:13.175Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/c2/403e7371b1ab0f6175d708ecc93cf18085ea9f903e8fe7d17c43df698f06/clang_format-21.1.8-py2.py3-none-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d12b864b596b80810cdd7f97556c485dc09cfe2952503958535f01359e025fbb", size = 1804755, upload-time = "2025-12-16T20:34:14.813Z" },
+    { url = "https://files.pythonhosted.org/packages/76/33/9e7db5fc4abefb25022d266957f666bfc263ae3e51abdd2c997d2880ceee/clang_format-21.1.8-py2.py3-none-manylinux_2_31_armv7l.whl", hash = "sha256:b81f1e909f5e7ef862a7818dc22b302a3ff407f3534e3395aa7ba26746cc890e", size = 1643208, upload-time = "2025-12-16T20:34:16.898Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/9f/43f4e384cb8943418f94943f682835f375f15b9cc64c526d73a7360f2b2f/clang_format-21.1.8-py2.py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:e10a5dca18a04997ad55c082bc0759edc7e337b24a2373ded109634fde12662a", size = 2701696, upload-time = "2025-12-16T20:34:19.043Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/6a/378187d72a465cebd3dbf7cd455e33b4931daa33e815b7865e6e65591a72/clang_format-21.1.8-py2.py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:10f7d7004d70b5e03fd3f764fc19fae89cd38d68b3482162cb09cac47c12c7b0", size = 2481266, upload-time = "2025-12-16T20:34:20.336Z" },
+    { url = "https://files.pythonhosted.org/packages/99/eb/2332edb1846d6832932191a590203a53ec69f585e718b51796335a1dcb6e/clang_format-21.1.8-py2.py3-none-musllinux_1_2_i686.whl", hash = "sha256:303d5fd53090422119136b1a458e98db429dedd5db0add50e70f885f8c95d82a", size = 2954000, upload-time = "2025-12-16T20:34:21.739Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/b5/eed5c95521b77d3cde024c3a23c7a80c46e78aa5b5a81c5cf935e7267588/clang_format-21.1.8-py2.py3-none-musllinux_1_2_ppc64le.whl", hash = "sha256:6b9e0b45cfaf4a18336a6db4666dd6a6aae840e38b038e6d568a65f43ade007c", size = 3076720, upload-time = "2025-12-16T20:34:23.139Z" },
+    { url = "https://files.pythonhosted.org/packages/14/55/7527fbe31423a1bb53653c2a2b20aa34a73ec33b99199bceaec0f5907295/clang_format-21.1.8-py2.py3-none-musllinux_1_2_s390x.whl", hash = "sha256:4dd0fee9eaee9915ba7fa08e60ee9ddfba1f754d10d71164482d9eb387c431f0", size = 3160892, upload-time = "2025-12-16T20:34:24.618Z" },
+    { url = "https://files.pythonhosted.org/packages/53/61/1623382bc78ef139c196473a5c76b840a071c9002cb5cd2694ac50327db9/clang_format-21.1.8-py2.py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:9731aecf954651004f184347d0c589d4e91a39ccda21262ee17c60f80a4408b2", size = 2812487, upload-time = "2025-12-16T20:34:26.505Z" },
+    { url = "https://files.pythonhosted.org/packages/53/e1/74f2000d44e4904472e5685afb98d19566c515026214733f02bbdc73d6d8/clang_format-21.1.8-py2.py3-none-win32.whl", hash = "sha256:2f5883ca83f718d8c2272e98b3cbda422fec520824b5a1e335c631dc6d812da7", size = 1271310, upload-time = "2025-12-16T20:34:28.179Z" },
+    { url = "https://files.pythonhosted.org/packages/69/7a/c49c8af9135c6a6dfb9cd103328ba7b6551643dce71b57e58ea940884015/clang_format-21.1.8-py2.py3-none-win_amd64.whl", hash = "sha256:a7606da55e31ebf5b63dd75800392e6cca7c595a74100c2cebcda2d742130732", size = 1426467, upload-time = "2025-12-16T20:34:29.805Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/d3/8790b539afb6cb0d4474705d3750e78a1f0847ab6d3ef1b00dd1ae52f364/clang_format-21.1.8-py2.py3-none-win_arm64.whl", hash = "sha256:1aa10b3f647268361d08bf4f17ce70964b8d9c04d5539e7d8acbebd14dc4a49c", size = 1327254, upload-time = "2025-12-16T20:34:31.579Z" },
+]
+
+[[package]]
 name = "click"
 version = "8.1.8"
 source = { registry = "https://pypi.org/simple" }
@@ -294,27 +319,21 @@ version = "0.0.0"
 source = { virtual = "." }
 dependencies = [
     { name = "black" },
+    { name = "clang-format" },
     { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "click", version = "8.3.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "jinja2" },
-    { name = "pyastyle" },
     { name = "rich" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "black" },
+    { name = "clang-format" },
     { name = "click" },
     { name = "jinja2" },
-    { name = "pyastyle" },
     { name = "rich" },
 ]
-
-[[package]]
-name = "pyastyle"
-version = "1.1.5"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/99/b1/c5f00383ef9d2dda1cecace84d152686442dd4c4ae97d1c4a3b83436f653/pyastyle-1.1.5.zip", hash = "sha256:89d6f0432cbc920e6649d9d7a50ba632c8305b28e07c9a9cf4346ef1b00369e3", size = 343648, upload-time = "2015-02-23T10:57:17.992Z" }
 
 [[package]]
 name = "pygments"


### PR DESCRIPTION
`pyastyle` hasn't been updated in more than 10 years; it seems the modern standard now is `clang-format`.

If we don't like the optional dependency strategy, where we just don't format if it's not on PATH, we can consider `clang_format` pip package. This will require some more work on the nix side to support since that package just assumes you have a "regular" (ubuntu, etc.) ld/libc.