### PR TITLE
ci: accept flake config

### DIFF
--- a/.github/actions/setup-nix/action.yml
+++ b/.github/actions/setup-nix/action.yml
@@ -6,7 +6,7 @@ runs:
     - uses: DeterminateSystems/determinate-nix-action@v3.14.0
       with:
         extra-conf: |
+          accept-flake-config = true
           extra-substituters = https://nix-cache.challenges.pwn.college
           extra-trusted-public-keys = nix-cache.challenges.pwn.college-1:Qj32MyanSS2fW+W7MtEFN3fWSksMT8l6IyJuG9Lw5bc=
     - uses: DeterminateSystems/flakehub-cache-action@v3.15.2
-

--- a/.github/actions/setup-nix/action.yml
+++ b/.github/actions/setup-nix/action.yml
@@ -7,6 +7,4 @@ runs:
       with:
         extra-conf: |
           accept-flake-config = true
-          extra-substituters = https://nix-cache.challenges.pwn.college
-          extra-trusted-public-keys = nix-cache.challenges.pwn.college-1:Qj32MyanSS2fW+W7MtEFN3fWSksMT8l6IyJuG9Lw5bc=
     - uses: DeterminateSystems/flakehub-cache-action@v3.15.2


### PR DESCRIPTION
This makes CI pass Nix's flake `nixConfig` trust check by setting `accept-flake-config = true` in the shared setup-nix action.

This removes the `warning: ignoring untrusted flake configuration setting 'extra-substituters'` / `extra-trusted-public-keys` noise while keeping the existing cache configuration from #117.
