### PR TITLE
ci: set nix cache priority

### DIFF
--- a/.github/workflows/publish-nix-cache.yml
+++ b/.github/workflows/publish-nix-cache.yml
@@ -14,6 +14,10 @@ concurrency:
   group: publish-nix-cache-${{ github.ref }}
   cancel-in-progress: true
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   publish-dev-shell-cache:
     runs-on: ubuntu-latest
@@ -26,12 +30,10 @@ jobs:
     - name: Build dev shell
       id: build-dev-shell
       run: |
-        set -euo pipefail
         printf 'path=%s\n' "$(nix build --no-link --print-out-paths .#devShells.x86_64-linux.default)" >> "${GITHUB_OUTPUT}"
 
     - name: Sign dev shell closure
       run: |
-        set -euo pipefail
         nix store sign --recursive --key-file <(echo '${{ secrets.NIX_CACHE_PRIVATE_KEY }}') '${{ steps.build-dev-shell.outputs.path }}'
 
     - name: Configure AWS credentials
@@ -39,7 +41,6 @@ jobs:
         AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_KEY }}
       run: |
-        set -euo pipefail
         nix shell nixpkgs#awscli --command aws configure set aws_access_key_id "${AWS_ACCESS_KEY_ID}"
         nix shell nixpkgs#awscli --command aws configure set aws_secret_access_key "${AWS_SECRET_ACCESS_KEY}"
         nix shell nixpkgs#awscli --command aws configure set region auto
@@ -49,7 +50,6 @@ jobs:
         R2_BUCKET_NAME: challenges-nix-cache
         R2_ENDPOINT: ${{ secrets.R2_ACCOUNT_ID }}.r2.cloudflarestorage.com
       run: |
-        set -euo pipefail
         nix copy --to "s3://${R2_BUCKET_NAME}?endpoint=${R2_ENDPOINT}" '${{ steps.build-dev-shell.outputs.path }}'
         printf 'StoreDir: /nix/store\nPriority: 50\n' | nix shell nixpkgs#awscli --command \
           aws s3 cp - "s3://${R2_BUCKET_NAME}/nix-cache-info" \
@@ -61,5 +61,4 @@ jobs:
       env:
         R2_PUBLIC_CACHE_DOMAIN: nix-cache.challenges.pwn.college
       run: |
-        set -euo pipefail
         nix path-info --store "https://${R2_PUBLIC_CACHE_DOMAIN}" '${{ steps.build-dev-shell.outputs.path }}' >/dev/null

--- a/.github/workflows/publish-nix-cache.yml
+++ b/.github/workflows/publish-nix-cache.yml
@@ -16,7 +16,7 @@ concurrency:
 
 defaults:
   run:
-    shell: bash
+    shell: bash --noprofile --norc -euo pipefail {0}
 
 jobs:
   publish-dev-shell-cache:

--- a/.github/workflows/publish-nix-cache.yml
+++ b/.github/workflows/publish-nix-cache.yml
@@ -50,6 +50,9 @@ jobs:
         R2_ENDPOINT: ${{ secrets.R2_ACCOUNT_ID }}.r2.cloudflarestorage.com
       run: |
         set -euo pipefail
+        nix copy --to "s3://${R2_BUCKET_NAME}?endpoint=${R2_ENDPOINT}" '${{ steps.build-dev-shell.outputs.path }}'
+        # Ensure the cache advertises lower priority than cache.nixos.org (40),
+        # so Nix will prefer cache.nixos.org when both caches have a path.
         cat > nix-cache-info <<'EOF'
         StoreDir: /nix/store
         Priority: 50
@@ -61,7 +64,6 @@ jobs:
           --content-type text/plain \
           --endpoint-url "https://${R2_ENDPOINT}" \
           >/dev/null
-        nix copy --to "s3://${R2_BUCKET_NAME}?endpoint=${R2_ENDPOINT}" '${{ steps.build-dev-shell.outputs.path }}'
 
     - name: Check cache availability from public domain
       env:

--- a/.github/workflows/publish-nix-cache.yml
+++ b/.github/workflows/publish-nix-cache.yml
@@ -44,7 +44,7 @@ jobs:
         nix shell nixpkgs#awscli --command aws configure set aws_secret_access_key "${AWS_SECRET_ACCESS_KEY}"
         nix shell nixpkgs#awscli --command aws configure set region auto
 
-    - name: Publish nix-cache-info (priority)
+    - name: Publish dev shell closure to R2 cache
       env:
         R2_BUCKET_NAME: challenges-nix-cache
         R2_ENDPOINT: ${{ secrets.R2_ACCOUNT_ID }}.r2.cloudflarestorage.com
@@ -61,13 +61,6 @@ jobs:
           --content-type text/plain \
           --endpoint-url "https://${R2_ENDPOINT}" \
           >/dev/null
-
-    - name: Publish dev shell closure to R2 cache
-      env:
-        R2_BUCKET_NAME: challenges-nix-cache
-        R2_ENDPOINT: ${{ secrets.R2_ACCOUNT_ID }}.r2.cloudflarestorage.com
-      run: |
-        set -euo pipefail
         nix copy --to "s3://${R2_BUCKET_NAME}?endpoint=${R2_ENDPOINT}" '${{ steps.build-dev-shell.outputs.path }}'
 
     - name: Check cache availability from public domain

--- a/.github/workflows/publish-nix-cache.yml
+++ b/.github/workflows/publish-nix-cache.yml
@@ -51,15 +51,9 @@ jobs:
       run: |
         set -euo pipefail
         nix copy --to "s3://${R2_BUCKET_NAME}?endpoint=${R2_ENDPOINT}" '${{ steps.build-dev-shell.outputs.path }}'
-        cat > nix-cache-info <<'EOF'
-        StoreDir: /nix/store
-        Priority: 50
-        EOF
-        nix shell nixpkgs#awscli --command aws s3api put-object \
-          --bucket "${R2_BUCKET_NAME}" \
-          --key nix-cache-info \
-          --body nix-cache-info \
-          --content-type text/plain \
+        printf 'StoreDir: /nix/store\nPriority: 50\n' | nix shell nixpkgs#awscli --command \
+          aws s3 cp - "s3://${R2_BUCKET_NAME}/nix-cache-info" \
+          --content-type text/x-nix-cache-info \
           --endpoint-url "https://${R2_ENDPOINT}" \
           >/dev/null
 

--- a/.github/workflows/publish-nix-cache.yml
+++ b/.github/workflows/publish-nix-cache.yml
@@ -51,8 +51,6 @@ jobs:
       run: |
         set -euo pipefail
         nix copy --to "s3://${R2_BUCKET_NAME}?endpoint=${R2_ENDPOINT}" '${{ steps.build-dev-shell.outputs.path }}'
-        # Ensure the cache advertises lower priority than cache.nixos.org (40),
-        # so Nix will prefer cache.nixos.org when both caches have a path.
         cat > nix-cache-info <<'EOF'
         StoreDir: /nix/store
         Priority: 50

--- a/.github/workflows/publish-nix-cache.yml
+++ b/.github/workflows/publish-nix-cache.yml
@@ -44,6 +44,24 @@ jobs:
         nix shell nixpkgs#awscli --command aws configure set aws_secret_access_key "${AWS_SECRET_ACCESS_KEY}"
         nix shell nixpkgs#awscli --command aws configure set region auto
 
+    - name: Publish nix-cache-info (priority)
+      env:
+        R2_BUCKET_NAME: challenges-nix-cache
+        R2_ENDPOINT: ${{ secrets.R2_ACCOUNT_ID }}.r2.cloudflarestorage.com
+      run: |
+        set -euo pipefail
+        cat > nix-cache-info <<'EOF'
+        StoreDir: /nix/store
+        Priority: 50
+        EOF
+        nix shell nixpkgs#awscli --command aws s3api put-object \
+          --bucket "${R2_BUCKET_NAME}" \
+          --key nix-cache-info \
+          --body nix-cache-info \
+          --content-type text/plain \
+          --endpoint-url "https://${R2_ENDPOINT}" \
+          >/dev/null
+
     - name: Publish dev shell closure to R2 cache
       env:
         R2_BUCKET_NAME: challenges-nix-cache


### PR DESCRIPTION
Publish a `nix-cache-info` file to the R2-backed binary cache with `Priority: 50`.

Since `cache.nixos.org` defaults to priority 40 (lower number = higher priority), this makes Nix prefer `cache.nixos.org` when both caches can serve a path, while still allowing fallback to `nix-cache.challenges.pwn.college`.

We intentionally do not set `WantMassQuery` here (default behavior).
