### PR TITLE
ci: git-crypt unlock on trusted runs

### DIFF
--- a/.github/actions/test-challenges/action.yml
+++ b/.github/actions/test-challenges/action.yml
@@ -46,6 +46,7 @@ runs:
       env:
         CHALLENGES_DIR: challenges/${{ inputs.challenges }}
         MODIFIED_SINCE: ${{ inputs.modified_since_ref }}
+        HAS_GPG_PRIVATE_KEY: ${{ inputs.gpg_private_key != '' }}
       run: |
         JOBS=$(( $(nproc) * 2 ))
         if [ -f "$CHALLENGES_DIR/dojo.yml" ]; then
@@ -54,8 +55,39 @@ runs:
           echo "::endgroup::"
         fi
         echo "::group::Challenges to be tested"
-        ./pwnshop list "$CHALLENGES_DIR" --modified-since="$MODIFIED_SINCE"
+        mapfile -t CHALLENGES < <(
+          ./pwnshop list "$CHALLENGES_DIR" --modified-since="$MODIFIED_SINCE" \
+            | while IFS= read -r line; do
+                [ -n "$line" ] || continue
+                # Filter out any wrapper/tooling noise; keep only valid challenge dirs.
+                if [ -d "$CHALLENGES_DIR/$line/challenge" ]; then
+                  echo "$line"
+                fi
+              done
+        )
+        printf '%s\n' "${CHALLENGES[@]}"
         echo "::endgroup::"
+        if [ "${#CHALLENGES[@]}" -eq 0 ]; then
+          echo "No challenges selected for testing."
+          exit 0
+        fi
+
+        if [ "$HAS_GPG_PRIVATE_KEY" != "true" ]; then
+          # No key available: remove encrypted files so private content cannot be used even accidentally.
+          git crypt status -e \
+            | sed -n 's/^[[:space:]]*encrypted:[[:space:]]*//p' \
+            | sort -u \
+            | while IFS= read -r p; do
+                [ -n "$p" ] || continue
+                rm -f "$p"
+              done
+        fi
+
+        args=()
+        for challenge in "${CHALLENGES[@]}"; do
+          args+=("$CHALLENGES_DIR/$challenge")
+        done
+
         echo "::group::Testing challenges"
-        ./pwnshop test --silent-failures --jobs "$JOBS" --modified-since="$MODIFIED_SINCE" "$CHALLENGES_DIR"
+        ./pwnshop test --silent-failures --jobs "$JOBS" "${args[@]}"
         echo "::endgroup::"

--- a/.github/actions/test-challenges/action.yml
+++ b/.github/actions/test-challenges/action.yml
@@ -20,60 +20,46 @@ runs:
       with:
         fetch-depth: 0
 
-    - name: Unlock git-crypt
-      if: ${{ inputs.gpg_private_key != '' }}
+    - name: Manage encrypted files
       shell: 'nix develop -c bash -euo pipefail {0}'
       env:
         GPG_PRIVATE_KEY: ${{ inputs.gpg_private_key }}
         CHALLENGES_DIR: challenges/${{ inputs.challenges }}
-      run: |
-        # This keeps the unlock surface area as small as possible.
-        git crypt status -e \
-          | sed -n 's/^[[:space:]]*encrypted:[[:space:]]*//p' \
-          | sort -u \
-          | while IFS= read -r p; do
-              case "$p" in
-                "$CHALLENGES_DIR"/*) ;;
-                *) rm -f "$p" ;;
-              esac
-            done
-
-        printf '%s' "$GPG_PRIVATE_KEY" | gpg --batch --import
-        git crypt unlock
-
-    - name: Test challenges
-      shell: 'nix develop -c bash -euo pipefail {0}'
-      env:
-        CHALLENGES_DIR: challenges/${{ inputs.challenges }}
         MODIFIED_SINCE: ${{ inputs.modified_since_ref }}
-        HAS_GPG_PRIVATE_KEY: ${{ inputs.gpg_private_key != '' }}
+        TARGETS_FILE: ${{ runner.temp }}/pwnshop-targets.txt
       run: |
-        JOBS=$(( $(nproc) * 2 ))
-        if [ -f "$CHALLENGES_DIR/dojo.yml" ]; then
-          echo "::group::Validating dojo.yml"
-          ./tools/dojo/parse-dojo-yml "$CHALLENGES_DIR/dojo.yml"
-          echo "::endgroup::"
-        fi
-        echo "::group::Challenges to be tested"
-        mapfile -t CHALLENGES < <(
-          ./pwnshop list "$CHALLENGES_DIR" --modified-since="$MODIFIED_SINCE" \
-            | while IFS= read -r line; do
-                [ -n "$line" ] || continue
-                # Filter out any wrapper/tooling noise; keep only valid challenge dirs.
-                if [ -d "$CHALLENGES_DIR/$line/challenge" ]; then
-                  echo "$line"
-                fi
-              done
-        )
-        printf '%s\n' "${CHALLENGES[@]}"
-        echo "::endgroup::"
-        if [ "${#CHALLENGES[@]}" -eq 0 ]; then
-          echo "No challenges selected for testing."
-          exit 0
-        fi
+        : >"$TARGETS_FILE"
 
-        if [ "$HAS_GPG_PRIVATE_KEY" != "true" ]; then
-          # No key available: remove encrypted files so private content cannot be used even accidentally.
+        # Compute the exact challenge directories we intend to test before mutating the working tree.
+        ./pwnshop list "$CHALLENGES_DIR" --modified-since="$MODIFIED_SINCE" \
+          | while IFS= read -r line; do
+              [ -n "$line" ] || continue
+              # Filter out any wrapper/tooling noise; keep only valid challenge dirs.
+              if [ -d "$CHALLENGES_DIR/$line/challenge" ]; then
+                printf '%s/%s\n' "$CHALLENGES_DIR" "$line"
+              fi
+            done \
+          | sort -u >"$TARGETS_FILE"
+
+        if [ -n "$GPG_PRIVATE_KEY" ]; then
+          # Prune encrypted files outside the group, then unlock remaining encrypted files.
+          # This keeps the unlock surface area as small as possible.
+          git crypt status -e \
+            | sed -n 's/^[[:space:]]*encrypted:[[:space:]]*//p' \
+            | sort -u \
+            | while IFS= read -r p; do
+                [ -n "$p" ] || continue
+                case "$p" in
+                  "$CHALLENGES_DIR"/*) ;;
+                  *) rm -f "$p" ;;
+                esac
+              done
+
+          printf '%s' "$GPG_PRIVATE_KEY" | gpg --batch --import
+          git crypt unlock
+        else
+          # No key: remove encrypted files so private content cannot be used even accidentally.
+          # Targets were computed above, so this won't affect which challenges we test.
           git crypt status -e \
             | sed -n 's/^[[:space:]]*encrypted:[[:space:]]*//p' \
             | sort -u \
@@ -83,11 +69,26 @@ runs:
               done
         fi
 
-        args=()
-        for challenge in "${CHALLENGES[@]}"; do
-          args+=("$CHALLENGES_DIR/$challenge")
-        done
+    - name: Test challenges
+      shell: 'nix develop -c bash -euo pipefail {0}'
+      env:
+        CHALLENGES_DIR: challenges/${{ inputs.challenges }}
+        TARGETS_FILE: ${{ runner.temp }}/pwnshop-targets.txt
+      run: |
+        JOBS=$(( $(nproc) * 2 ))
+        if [ -f "$CHALLENGES_DIR/dojo.yml" ]; then
+          echo "::group::Validating dojo.yml"
+          ./tools/dojo/parse-dojo-yml "$CHALLENGES_DIR/dojo.yml"
+          echo "::endgroup::"
+        fi
+        echo "::group::Challenges to be tested"
+        sed -e "s#^$CHALLENGES_DIR/##" "$TARGETS_FILE" || true
+        echo "::endgroup::"
+        if [ ! -s "$TARGETS_FILE" ]; then
+          echo "No challenges selected for testing."
+          exit 0
+        fi
 
         echo "::group::Testing challenges"
-        ./pwnshop test --silent-failures --jobs "$JOBS" "${args[@]}"
+        xargs -r -d '\n' ./pwnshop test --silent-failures --jobs "$JOBS" <"$TARGETS_FILE"
         echo "::endgroup::"

--- a/.github/actions/test-challenges/action.yml
+++ b/.github/actions/test-challenges/action.yml
@@ -60,5 +60,5 @@ runs:
         ./pwnshop list "$CHALLENGES_DIR" --modified-since="$MODIFIED_SINCE"
         echo "::endgroup::"
         echo "::group::Testing challenges"
-        ./pwnshop test --jobs "$JOBS" --modified-since="$MODIFIED_SINCE" "$CHALLENGES_DIR"
+        ./pwnshop test --silent-failures --jobs "$JOBS" --modified-since="$MODIFIED_SINCE" "$CHALLENGES_DIR"
         echo "::endgroup::"

--- a/.github/actions/test-challenges/action.yml
+++ b/.github/actions/test-challenges/action.yml
@@ -27,16 +27,22 @@ runs:
         GPG_PRIVATE_KEY: ${{ inputs.gpg_private_key }}
         CHALLENGES_DIR: challenges/${{ inputs.challenges }}
       run: |
+        # Delete encrypted content outside the specific group before unlocking.
+        # This keeps the unlock surface area as small as possible.
+        git crypt status -e \
+          | sed -n 's/^[[:space:]]*encrypted:[[:space:]]*//p' \
+          | grep -E '^challenges/' \
+          | xargs -r -n1 dirname \
+          | sort -u \
+          | while IFS= read -r d; do
+              case "$d" in
+                "$CHALLENGES_DIR"/*) ;;
+                *) rm -rf "$d" ;;
+              esac
+            done
+
         printf '%s' "$GPG_PRIVATE_KEY" | gpg --batch --import
         git crypt unlock
-        # Limit decrypted tests_private to the specific group we're testing.
-        # git-crypt unlock is repo-wide, so we cleanup other groups to reduce exposure and work.
-        find challenges -type d -name tests_private -print0 | while IFS= read -r -d '' d; do
-          case "$d" in
-            "$CHALLENGES_DIR"/*) ;;
-            *) rm -rf "$d" ;;
-          esac
-        done
 
     - name: Test challenges
       shell: 'nix develop -c bash -euo pipefail {0}'

--- a/.github/actions/test-challenges/action.yml
+++ b/.github/actions/test-challenges/action.yml
@@ -51,14 +51,27 @@ runs:
         MODIFIED_SINCE: ${{ inputs.modified_since_ref }}
       run: |
         JOBS=$(( $(nproc) * 2 ))
+        LOG_ROOT="${RUNNER_TEMP:-/tmp}/pwnshop-logs/${{ inputs.challenges }}"
+        mkdir -p "$LOG_ROOT"
+
+        # Capture all stdout/stderr from pwnshop invocations to avoid leaking sensitive output
+        # (especially when tests_private is unlocked on trusted runs).
+        exec 3>&1 4>&2
+        exec >"$LOG_ROOT/pwnshop.log" 2>&1
+        cleanup() {
+          rc=$?
+          exec 1>&3 2>&4
+          if [ "$rc" -ne 0 ]; then
+            echo "::error::Challenge tests failed. Logs captured under $LOG_ROOT." >&2
+          fi
+          exit "$rc"
+        }
+        trap cleanup EXIT
         if [ -f "$CHALLENGES_DIR/dojo.yml" ]; then
-          echo "::group::Validating dojo.yml"
+          echo "Validating dojo.yml"
           ./tools/dojo/parse-dojo-yml "$CHALLENGES_DIR/dojo.yml"
-          echo "::endgroup::"
         fi
-        echo "::group::Challenges to be tested"
+        echo "Challenges to be tested"
         ./pwnshop list "$CHALLENGES_DIR" --modified-since="$MODIFIED_SINCE"
-        echo "::endgroup::"
-        echo "::group::Testing challenges"
-        ./pwnshop test --jobs "$JOBS" --modified-since="$MODIFIED_SINCE" "$CHALLENGES_DIR"
-        echo "::endgroup::"
+        echo "Testing challenges"
+        ./pwnshop test --jobs "$JOBS" --log-failures "$LOG_ROOT/failures" --modified-since="$MODIFIED_SINCE" "$CHALLENGES_DIR"

--- a/.github/actions/test-challenges/action.yml
+++ b/.github/actions/test-challenges/action.yml
@@ -30,7 +30,6 @@ runs:
         # This keeps the unlock surface area as small as possible.
         git crypt status -e \
           | sed -n 's/^[[:space:]]*encrypted:[[:space:]]*//p' \
-          | grep -E '^challenges/' \
           | sort -u \
           | while IFS= read -r p; do
               case "$p" in

--- a/.github/actions/test-challenges/action.yml
+++ b/.github/actions/test-challenges/action.yml
@@ -31,8 +31,8 @@ runs:
         # This keeps the unlock surface area as small as possible.
         git crypt status -e \
           | sed -n 's/^[[:space:]]*encrypted:[[:space:]]*//p' \
-          | grep -E '^challenges/' \
-          | xargs -r -n1 dirname \
+          | grep -E '^challenges/.*/tests_private/' \
+          | sed -e 's#/tests_private/.*#/tests_private#' \
           | sort -u \
           | while IFS= read -r d; do
               case "$d" in

--- a/.github/actions/test-challenges/action.yml
+++ b/.github/actions/test-challenges/action.yml
@@ -30,13 +30,12 @@ runs:
         # This keeps the unlock surface area as small as possible.
         git crypt status -e \
           | sed -n 's/^[[:space:]]*encrypted:[[:space:]]*//p' \
-          | grep -E '^challenges/.*/tests_private/' \
-          | sed -e 's#/tests_private/.*#/tests_private#' \
+          | grep -E '^challenges/' \
           | sort -u \
-          | while IFS= read -r d; do
-              case "$d" in
+          | while IFS= read -r p; do
+              case "$p" in
                 "$CHALLENGES_DIR"/*) ;;
-                *) rm -rf "$d" ;;
+                *) rm -f "$p" ;;
               esac
             done
 

--- a/.github/actions/test-challenges/action.yml
+++ b/.github/actions/test-challenges/action.yml
@@ -27,7 +27,6 @@ runs:
         GPG_PRIVATE_KEY: ${{ inputs.gpg_private_key }}
         CHALLENGES_DIR: challenges/${{ inputs.challenges }}
       run: |
-        # Delete encrypted content outside the specific group before unlocking.
         # This keeps the unlock surface area as small as possible.
         git crypt status -e \
           | sed -n 's/^[[:space:]]*encrypted:[[:space:]]*//p' \

--- a/.github/actions/test-challenges/action.yml
+++ b/.github/actions/test-challenges/action.yml
@@ -25,24 +25,8 @@ runs:
       env:
         GPG_PRIVATE_KEY: ${{ inputs.gpg_private_key }}
         CHALLENGES_DIR: challenges/${{ inputs.challenges }}
-        MODIFIED_SINCE: ${{ inputs.modified_since_ref }}
-        TARGETS_FILE: ${{ runner.temp }}/pwnshop-targets.txt
       run: |
-        : >"$TARGETS_FILE"
-
-        # Compute the exact challenge directories we intend to test before mutating the working tree.
-        ./pwnshop list "$CHALLENGES_DIR" --modified-since="$MODIFIED_SINCE" \
-          | while IFS= read -r line; do
-              [ -n "$line" ] || continue
-              # Filter out any wrapper/tooling noise; keep only valid challenge dirs.
-              if [ -d "$CHALLENGES_DIR/$line/challenge" ]; then
-                printf '%s/%s\n' "$CHALLENGES_DIR" "$line"
-              fi
-            done \
-          | sort -u >"$TARGETS_FILE"
-
         if [ -n "$GPG_PRIVATE_KEY" ]; then
-          # Prune encrypted files outside the group, then unlock remaining encrypted files.
           # This keeps the unlock surface area as small as possible.
           git crypt status -e \
             | sed -n 's/^[[:space:]]*encrypted:[[:space:]]*//p' \
@@ -59,7 +43,6 @@ runs:
           git crypt unlock
         else
           # No key: remove encrypted files so private content cannot be used even accidentally.
-          # Targets were computed above, so this won't affect which challenges we test.
           git crypt status -e \
             | sed -n 's/^[[:space:]]*encrypted:[[:space:]]*//p' \
             | sort -u \
@@ -73,7 +56,7 @@ runs:
       shell: 'nix develop -c bash -euo pipefail {0}'
       env:
         CHALLENGES_DIR: challenges/${{ inputs.challenges }}
-        TARGETS_FILE: ${{ runner.temp }}/pwnshop-targets.txt
+        MODIFIED_SINCE: ${{ inputs.modified_since_ref }}
       run: |
         JOBS=$(( $(nproc) * 2 ))
         if [ -f "$CHALLENGES_DIR/dojo.yml" ]; then
@@ -82,13 +65,9 @@ runs:
           echo "::endgroup::"
         fi
         echo "::group::Challenges to be tested"
-        sed -e "s#^$CHALLENGES_DIR/##" "$TARGETS_FILE" || true
+        ./pwnshop list "$CHALLENGES_DIR" --modified-since="$MODIFIED_SINCE"
         echo "::endgroup::"
-        if [ ! -s "$TARGETS_FILE" ]; then
-          echo "No challenges selected for testing."
-          exit 0
-        fi
 
         echo "::group::Testing challenges"
-        xargs -r -d '\n' ./pwnshop test --silent-failures --jobs "$JOBS" <"$TARGETS_FILE"
+        ./pwnshop test --silent-failures --jobs "$JOBS" --modified-since="$MODIFIED_SINCE" "$CHALLENGES_DIR"
         echo "::endgroup::"

--- a/.github/actions/test-challenges/action.yml
+++ b/.github/actions/test-challenges/action.yml
@@ -8,10 +8,8 @@ inputs:
     description: Base ref challenges have been modified since.
     required: false
     default: ""
-  gpg_root_private_key:
-    description: >-
-      GPG private key used to unlock git-crypt so tests_private can be decrypted
-      on trusted runs (push to main, schedule, manual).
+  gpg_private_key:
+    description: GPG private key used to unlock git-crypt.
     required: false
     default: ""
 runs:
@@ -23,13 +21,22 @@ runs:
         fetch-depth: 0
 
     - name: Unlock git-crypt
-      if: ${{ inputs.gpg_root_private_key != '' }}
+      if: ${{ inputs.gpg_private_key != '' }}
       shell: 'nix develop -c bash -euo pipefail {0}'
       env:
-        GPG_ROOT_PRIVATE_KEY: ${{ inputs.gpg_root_private_key }}
+        GPG_PRIVATE_KEY: ${{ inputs.gpg_private_key }}
+        CHALLENGES_DIR: challenges/${{ inputs.challenges }}
       run: |
-        printf '%s' "$GPG_ROOT_PRIVATE_KEY" | gpg --batch --import
+        printf '%s' "$GPG_PRIVATE_KEY" | gpg --batch --import
         git crypt unlock
+        # Limit decrypted tests_private to the specific group we're testing.
+        # git-crypt unlock is repo-wide, so we cleanup other groups to reduce exposure and work.
+        find challenges -type d -name tests_private -print0 | while IFS= read -r -d '' d; do
+          case "$d" in
+            "$CHALLENGES_DIR"/*) ;;
+            *) rm -rf "$d" ;;
+          esac
+        done
 
     - name: Test challenges
       shell: 'nix develop -c bash -euo pipefail {0}'

--- a/.github/actions/test-challenges/action.yml
+++ b/.github/actions/test-challenges/action.yml
@@ -26,30 +26,25 @@ runs:
         GPG_PRIVATE_KEY: ${{ inputs.gpg_private_key }}
         CHALLENGES_DIR: challenges/${{ inputs.challenges }}
       run: |
+        # If we have a key, keep encrypted content for this group and delete everything else.
+        # If we don't, delete all encrypted files so private content can't be used accidentally.
+        git crypt status -e \
+          | sed -n 's/^[[:space:]]*encrypted:[[:space:]]*//p' \
+          | sort -u \
+          | while IFS= read -r encrypted_path; do
+              [ -n "$encrypted_path" ] || continue
+              if [ -n "$GPG_PRIVATE_KEY" ]; then
+                case "$encrypted_path" in
+                  "$CHALLENGES_DIR"/*) continue ;;
+                esac
+              fi
+              rm -f "$encrypted_path"
+            done
+
         if [ -n "$GPG_PRIVATE_KEY" ]; then
           # This keeps the unlock surface area as small as possible.
-          git crypt status -e \
-            | sed -n 's/^[[:space:]]*encrypted:[[:space:]]*//p' \
-            | sort -u \
-            | while IFS= read -r p; do
-                [ -n "$p" ] || continue
-                case "$p" in
-                  "$CHALLENGES_DIR"/*) ;;
-                  *) rm -f "$p" ;;
-                esac
-              done
-
           printf '%s' "$GPG_PRIVATE_KEY" | gpg --batch --import
           git crypt unlock
-        else
-          # No key: remove encrypted files so private content cannot be used even accidentally.
-          git crypt status -e \
-            | sed -n 's/^[[:space:]]*encrypted:[[:space:]]*//p' \
-            | sort -u \
-            | while IFS= read -r p; do
-                [ -n "$p" ] || continue
-                rm -f "$p"
-              done
         fi
 
     - name: Test challenges

--- a/.github/actions/test-challenges/action.yml
+++ b/.github/actions/test-challenges/action.yml
@@ -8,6 +8,12 @@ inputs:
     description: Base ref challenges have been modified since.
     required: false
     default: ""
+  gpg_root_private_key:
+    description: >-
+      GPG private key used to unlock git-crypt so tests_private can be decrypted
+      on trusted runs (push to main, schedule, manual).
+    required: false
+    default: ""
 runs:
   using: composite
   steps:
@@ -16,10 +22,14 @@ runs:
       with:
         fetch-depth: 0
 
-    - name: Remove encrypted directories
+    - name: Unlock git-crypt
+      if: ${{ inputs.gpg_root_private_key != '' }}
       shell: 'nix develop -c bash -euo pipefail {0}'
+      env:
+        GPG_ROOT_PRIVATE_KEY: ${{ inputs.gpg_root_private_key }}
       run: |
-        git crypt status -e | sed -e "s/ *encrypted: //" | xargs -r dirname | xargs -r rm -rf
+        printf '%s' "$GPG_ROOT_PRIVATE_KEY" | gpg --batch --import
+        git crypt unlock
 
     - name: Test challenges
       shell: 'nix develop -c bash -euo pipefail {0}'

--- a/.github/actions/test-challenges/action.yml
+++ b/.github/actions/test-challenges/action.yml
@@ -42,7 +42,6 @@ runs:
             done
 
         if [ -n "$GPG_PRIVATE_KEY" ]; then
-          # This keeps the unlock surface area as small as possible.
           printf '%s' "$GPG_PRIVATE_KEY" | gpg --batch --import
           git crypt unlock
         fi

--- a/.github/actions/test-challenges/action.yml
+++ b/.github/actions/test-challenges/action.yml
@@ -51,27 +51,14 @@ runs:
         MODIFIED_SINCE: ${{ inputs.modified_since_ref }}
       run: |
         JOBS=$(( $(nproc) * 2 ))
-        LOG_ROOT="${RUNNER_TEMP:-/tmp}/pwnshop-logs/${{ inputs.challenges }}"
-        mkdir -p "$LOG_ROOT"
-
-        # Capture all stdout/stderr from pwnshop invocations to avoid leaking sensitive output
-        # (especially when tests_private is unlocked on trusted runs).
-        exec 3>&1 4>&2
-        exec >"$LOG_ROOT/pwnshop.log" 2>&1
-        cleanup() {
-          rc=$?
-          exec 1>&3 2>&4
-          if [ "$rc" -ne 0 ]; then
-            echo "::error::Challenge tests failed. Logs captured under $LOG_ROOT." >&2
-          fi
-          exit "$rc"
-        }
-        trap cleanup EXIT
         if [ -f "$CHALLENGES_DIR/dojo.yml" ]; then
-          echo "Validating dojo.yml"
+          echo "::group::Validating dojo.yml"
           ./tools/dojo/parse-dojo-yml "$CHALLENGES_DIR/dojo.yml"
+          echo "::endgroup::"
         fi
-        echo "Challenges to be tested"
+        echo "::group::Challenges to be tested"
         ./pwnshop list "$CHALLENGES_DIR" --modified-since="$MODIFIED_SINCE"
-        echo "Testing challenges"
-        ./pwnshop test --jobs "$JOBS" --log-failures "$LOG_ROOT/failures" --modified-since="$MODIFIED_SINCE" "$CHALLENGES_DIR"
+        echo "::endgroup::"
+        echo "::group::Testing challenges"
+        ./pwnshop test --jobs "$JOBS" --modified-since="$MODIFIED_SINCE" "$CHALLENGES_DIR"
+        echo "::endgroup::"

--- a/.github/actions/test-challenges/action.yml
+++ b/.github/actions/test-challenges/action.yml
@@ -26,24 +26,26 @@ runs:
         GPG_PRIVATE_KEY: ${{ inputs.gpg_private_key }}
         CHALLENGES_DIR: challenges/${{ inputs.challenges }}
       run: |
-        # If we have a key, keep encrypted content for this group and delete everything else.
-        # If we don't, delete all encrypted files so private content can't be used accidentally.
-        git crypt status -e \
-          | sed -n 's/^[[:space:]]*encrypted:[[:space:]]*//p' \
-          | sort -u \
-          | while IFS= read -r encrypted_path; do
-              [ -n "$encrypted_path" ] || continue
-              if [ -n "$GPG_PRIVATE_KEY" ]; then
-                case "$encrypted_path" in
-                  "$CHALLENGES_DIR"/*) continue ;;
-                esac
-              fi
-              rm -f "$encrypted_path"
-            done
+        encrypted_paths() {
+          git crypt status -e \
+            | sed -n 's/^[[:space:]]*encrypted:[[:space:]]*//p' \
+            | sort -u
+        }
 
         if [ -n "$GPG_PRIVATE_KEY" ]; then
+          # Keep encrypted content for this group, delete everything else, then unlock.
+          encrypted_paths | while IFS= read -r encrypted_path; do
+            case "$encrypted_path" in
+              "$CHALLENGES_DIR"/*) ;;
+              *) rm -f "$encrypted_path" ;;
+            esac
+          done
+
           printf '%s' "$GPG_PRIVATE_KEY" | gpg --batch --import
           git crypt unlock
+        else
+          # No key: delete all encrypted files so private content can't be used accidentally.
+          encrypted_paths | xargs -r rm -f
         fi
 
     - name: Test challenges

--- a/.github/actions/test-challenges/action.yml
+++ b/.github/actions/test-challenges/action.yml
@@ -33,7 +33,6 @@ runs:
         }
 
         if [ -n "$GPG_PRIVATE_KEY" ]; then
-          # Keep encrypted content for this group, delete everything else, then unlock.
           encrypted_paths | while IFS= read -r encrypted_path; do
             case "$encrypted_path" in
               "$CHALLENGES_DIR"/*) ;;
@@ -44,7 +43,6 @@ runs:
           printf '%s' "$GPG_PRIVATE_KEY" | gpg --batch --import
           git crypt unlock
         else
-          # No key: delete all encrypted files so private content can't be used accidentally.
           encrypted_paths | xargs -r rm -f
         fi
 

--- a/.github/workflows/publish-challenges.yml
+++ b/.github/workflows/publish-challenges.yml
@@ -46,6 +46,7 @@ jobs:
       with:
         challenges: ${{ matrix.challenges }}
         modified_since_ref: ""
+        gpg_private_key: ${{ secrets.GPG_ROOT_PRIVATE_KEY }}
 
     - name: Install rclone
       run: sudo apt-get update && sudo apt-get install -y rclone

--- a/.github/workflows/test-challenges.yml
+++ b/.github/workflows/test-challenges.yml
@@ -46,12 +46,14 @@ jobs:
           // Trusted contexts:
           // - Non-PR events (workflow_dispatch/schedule) are trusted.
           // - PRs from the main repo (not a fork) are trusted; fork PRs are not.
-          let trusted = true;
-          if (context.eventName === "pull_request") {
+          let trusted = false;
+          if (context.eventName !== "pull_request") {
+            trusted = true;
+          } else {
             const pr = context.payload.pull_request;
             const headRepo = pr?.head?.repo?.full_name;
             const baseRepo = pr?.base?.repo?.full_name;
-            trusted = Boolean(headRepo && baseRepo && headRepo === baseRepo);
+            if (headRepo && baseRepo && headRepo === baseRepo) trusted = true;
           }
           core.setOutput("trusted", trusted ? "true" : "false");
 

--- a/.github/workflows/test-challenges.yml
+++ b/.github/workflows/test-challenges.yml
@@ -1,6 +1,8 @@
 name: Test Challenges
 
 on:
+  push:
+    branches: [ main ]
   pull_request:
     branches: [ main ]
   workflow_dispatch:
@@ -28,7 +30,7 @@ jobs:
 
   test-challenges:
     needs: determine-modified-challenges
-    if: ${{ needs.determine-modified-challenges.outputs.challenges != '[]' }}
+    if: ${{ github.event_name == 'pull_request' && needs.determine-modified-challenges.outputs.challenges != '[]' }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -45,6 +47,38 @@ jobs:
       with:
         challenges: ${{ matrix.challenges }}
         modified_since_ref: ${{ needs.determine-modified-challenges.outputs.modified_since_ref }}
+
+    - name: Report runtime storage
+      if: always()
+      uses: ./.github/actions/report-runtime-storage
+
+  test-challenges-trusted:
+    needs: determine-modified-challenges
+    if: ${{ github.event_name != 'pull_request' && needs.determine-modified-challenges.outputs.challenges != '[]' }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        challenges: ${{ fromJson(needs.determine-modified-challenges.outputs.challenges) }}
+
+    steps:
+    - uses: actions/checkout@v4
+    - uses: ./.github/actions/setup-nix
+    - uses: ./.github/actions/setup-challenge-runtime
+
+    - name: Ensure git-crypt key is available
+      run: |
+        if [ -z "${{ secrets.GPG_ROOT_PRIVATE_KEY }}" ]; then
+          echo "::error::secrets.GPG_ROOT_PRIVATE_KEY is not set; cannot unlock tests_private."
+          exit 1
+        fi
+
+    - name: Test challenges
+      uses: ./.github/actions/test-challenges
+      with:
+        challenges: ${{ matrix.challenges }}
+        modified_since_ref: ${{ needs.determine-modified-challenges.outputs.modified_since_ref }}
+        gpg_root_private_key: ${{ secrets.GPG_ROOT_PRIVATE_KEY }}
 
     - name: Report runtime storage
       if: always()

--- a/.github/workflows/test-challenges.yml
+++ b/.github/workflows/test-challenges.yml
@@ -78,7 +78,7 @@ jobs:
       with:
         challenges: ${{ matrix.challenges }}
         modified_since_ref: ${{ needs.determine-modified-challenges.outputs.modified_since_ref }}
-        gpg_root_private_key: ${{ secrets.GPG_ROOT_PRIVATE_KEY }}
+        gpg_private_key: ${{ secrets.GPG_ROOT_PRIVATE_KEY }}
 
     - name: Report runtime storage
       if: always()

--- a/.github/workflows/test-challenges.yml
+++ b/.github/workflows/test-challenges.yml
@@ -1,8 +1,6 @@
 name: Test Challenges
 
 on:
-  push:
-    branches: [ main ]
   pull_request:
     branches: [ main ]
   workflow_dispatch:

--- a/.github/workflows/test-challenges.yml
+++ b/.github/workflows/test-challenges.yml
@@ -47,9 +47,9 @@ jobs:
           // - Non-PR events (workflow_dispatch/schedule) are trusted.
           // - PRs from the main repo (not a fork) are trusted; fork PRs are not.
           let trusted = false;
-          if (context.eventName !== "pull_request") {
+          if (context.eventName === "workflow_dispatch" || context.eventName === "schedule") {
             trusted = true;
-          } else {
+          } else if (context.eventName === "pull_request") {
             const pr = context.payload.pull_request;
             const headRepo = pr?.head?.repo?.full_name;
             const baseRepo = pr?.base?.repo?.full_name;

--- a/.github/workflows/test-challenges.yml
+++ b/.github/workflows/test-challenges.yml
@@ -51,14 +51,6 @@ jobs:
       if: always()
       uses: ./.github/actions/report-runtime-storage
 
-    - name: Ensure git-crypt key is available
-      if: ${{ github.event_name != 'pull_request' }}
-      run: |
-        if [ -z "${{ secrets.GPG_ROOT_PRIVATE_KEY }}" ]; then
-          echo "::error::secrets.GPG_ROOT_PRIVATE_KEY is not set; cannot unlock tests_private."
-          exit 1
-        fi
-
     - name: Test challenges (trusted)
       if: ${{ github.event_name != 'pull_request' }}
       uses: ./.github/actions/test-challenges

--- a/.github/workflows/test-challenges.yml
+++ b/.github/workflows/test-challenges.yml
@@ -37,11 +37,90 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+
+    - name: Determine trust
+      id: trust
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const owner = context.repo.owner;
+          const repo = context.repo.repo;
+
+          async function isTrusted() {
+            if (context.eventName !== "pull_request") return true;
+
+            const pr = context.payload.pull_request;
+            if (!pr) return false;
+
+            const prAuthor = pr.user?.login;
+            if (!prAuthor) return false;
+
+            // Fetch maintainers.yml from the PR base commit (not the PR code).
+            const baseSha = pr.base?.sha;
+            if (!baseSha) return false;
+
+            let content;
+            try {
+              const res = await github.rest.repos.getContent({
+                owner,
+                repo,
+                path: "maintainers.yml",
+                ref: baseSha,
+              });
+              if (Array.isArray(res.data) || res.data.type !== "file" || !res.data.content) return false;
+              content = Buffer.from(res.data.content, res.data.encoding || "base64").toString("utf8");
+            } catch (e) {
+              core.warning(`Failed to fetch maintainers.yml at ${baseSha}: ${e.message || e}`);
+              return false;
+            }
+
+            // Minimal parser for maintainers.yml: extract `github:` and `groups: [...]`.
+            const entries = [];
+            let current = {};
+            for (const rawLine of content.split("\n")) {
+              const line = rawLine.trimEnd();
+              if (/^\\s*-\\s+name:/.test(line)) {
+                if (current.github) entries.push(current);
+                current = {};
+                continue;
+              }
+              const mGithub = line.match(/^\\s*github:\\s*(\\S+)\\s*$/);
+              if (mGithub) {
+                current.github = mGithub[1];
+                continue;
+              }
+              const mGroups = line.match(/^\\s*groups:\\s*(\\[[^\\]]*\\])\\s*$/);
+              if (mGroups) {
+                const inside = mGroups[1].replace(/^\\[/, "").replace(/\\]$/, "");
+                const groups = inside
+                  .split(",")
+                  .map((s) => s.trim())
+                  .filter(Boolean)
+                  .map((s) => s.replace(/^['\"]|['\"]$/g, ""));
+                current.groups = groups;
+              }
+            }
+            if (current.github) entries.push(current);
+
+            const match = entries.find((e) => e.github === prAuthor);
+            return Boolean(match && Array.isArray(match.groups) && match.groups.includes("*"));
+          }
+
+          core.setOutput("trusted", (await isTrusted()) ? "true" : "false");
+
     - uses: ./.github/actions/setup-nix
     - uses: ./.github/actions/setup-challenge-runtime
 
+    - name: Test challenges (trusted)
+      if: ${{ steps.trust.outputs.trusted == 'true' }}
+      uses: ./.github/actions/test-challenges
+      with:
+        challenges: ${{ matrix.challenges }}
+        modified_since_ref: ${{ needs.determine-modified-challenges.outputs.modified_since_ref }}
+        gpg_private_key: ${{ secrets.GPG_ROOT_PRIVATE_KEY }}
+
     - name: Test challenges (untrusted)
-      if: ${{ github.event_name == 'pull_request' }}
+      if: ${{ steps.trust.outputs.trusted != 'true' }}
       uses: ./.github/actions/test-challenges
       with:
         challenges: ${{ matrix.challenges }}
@@ -50,11 +129,3 @@ jobs:
     - name: Report runtime storage
       if: always()
       uses: ./.github/actions/report-runtime-storage
-
-    - name: Test challenges (trusted)
-      if: ${{ github.event_name != 'pull_request' }}
-      uses: ./.github/actions/test-challenges
-      with:
-        challenges: ${{ matrix.challenges }}
-        modified_since_ref: ${{ needs.determine-modified-challenges.outputs.modified_since_ref }}
-        gpg_private_key: ${{ secrets.GPG_ROOT_PRIVATE_KEY }}

--- a/.github/workflows/test-challenges.yml
+++ b/.github/workflows/test-challenges.yml
@@ -28,7 +28,7 @@ jobs:
 
   test-challenges:
     needs: determine-modified-challenges
-    if: ${{ github.event_name == 'pull_request' && needs.determine-modified-challenges.outputs.challenges != '[]' }}
+    if: ${{ needs.determine-modified-challenges.outputs.challenges != '[]' }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -40,7 +40,8 @@ jobs:
     - uses: ./.github/actions/setup-nix
     - uses: ./.github/actions/setup-challenge-runtime
 
-    - name: Test challenges
+    - name: Test challenges (untrusted)
+      if: ${{ github.event_name == 'pull_request' }}
       uses: ./.github/actions/test-challenges
       with:
         challenges: ${{ matrix.challenges }}
@@ -50,34 +51,18 @@ jobs:
       if: always()
       uses: ./.github/actions/report-runtime-storage
 
-  test-challenges-trusted:
-    needs: determine-modified-challenges
-    if: ${{ github.event_name != 'pull_request' && needs.determine-modified-challenges.outputs.challenges != '[]' }}
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        challenges: ${{ fromJson(needs.determine-modified-challenges.outputs.challenges) }}
-
-    steps:
-    - uses: actions/checkout@v4
-    - uses: ./.github/actions/setup-nix
-    - uses: ./.github/actions/setup-challenge-runtime
-
     - name: Ensure git-crypt key is available
+      if: ${{ github.event_name != 'pull_request' }}
       run: |
         if [ -z "${{ secrets.GPG_ROOT_PRIVATE_KEY }}" ]; then
           echo "::error::secrets.GPG_ROOT_PRIVATE_KEY is not set; cannot unlock tests_private."
           exit 1
         fi
 
-    - name: Test challenges
+    - name: Test challenges (trusted)
+      if: ${{ github.event_name != 'pull_request' }}
       uses: ./.github/actions/test-challenges
       with:
         challenges: ${{ matrix.challenges }}
         modified_since_ref: ${{ needs.determine-modified-challenges.outputs.modified_since_ref }}
         gpg_private_key: ${{ secrets.GPG_ROOT_PRIVATE_KEY }}
-
-    - name: Report runtime storage
-      if: always()
-      uses: ./.github/actions/report-runtime-storage

--- a/.github/workflows/test-challenges.yml
+++ b/.github/workflows/test-challenges.yml
@@ -43,70 +43,17 @@ jobs:
       uses: actions/github-script@v7
       with:
         script: |
-          const owner = context.repo.owner;
-          const repo = context.repo.repo;
-
-          async function isTrusted() {
-            if (context.eventName !== "pull_request") return true;
-
+          // Trusted contexts:
+          // - Non-PR events (workflow_dispatch/schedule) are trusted.
+          // - PRs from the main repo (not a fork) are trusted; fork PRs are not.
+          let trusted = true;
+          if (context.eventName === "pull_request") {
             const pr = context.payload.pull_request;
-            if (!pr) return false;
-
-            const prAuthor = pr.user?.login;
-            if (!prAuthor) return false;
-
-            // Fetch maintainers.yml from the PR base commit (not the PR code).
-            const baseSha = pr.base?.sha;
-            if (!baseSha) return false;
-
-            let content;
-            try {
-              const res = await github.rest.repos.getContent({
-                owner,
-                repo,
-                path: "maintainers.yml",
-                ref: baseSha,
-              });
-              if (Array.isArray(res.data) || res.data.type !== "file" || !res.data.content) return false;
-              content = Buffer.from(res.data.content, res.data.encoding || "base64").toString("utf8");
-            } catch (e) {
-              core.warning(`Failed to fetch maintainers.yml at ${baseSha}: ${e.message || e}`);
-              return false;
-            }
-
-            // Minimal parser for maintainers.yml: extract `github:` and `groups: [...]`.
-            const entries = [];
-            let current = {};
-            for (const rawLine of content.split("\n")) {
-              const line = rawLine.trimEnd();
-              if (/^\\s*-\\s+name:/.test(line)) {
-                if (current.github) entries.push(current);
-                current = {};
-                continue;
-              }
-              const mGithub = line.match(/^\\s*github:\\s*(\\S+)\\s*$/);
-              if (mGithub) {
-                current.github = mGithub[1];
-                continue;
-              }
-              const mGroups = line.match(/^\\s*groups:\\s*(\\[[^\\]]*\\])\\s*$/);
-              if (mGroups) {
-                const inside = mGroups[1].replace(/^\\[/, "").replace(/\\]$/, "");
-                const groups = inside
-                  .split(",")
-                  .map((s) => s.trim())
-                  .filter(Boolean)
-                  .map((s) => s.replace(/^['\"]|['\"]$/g, ""));
-                current.groups = groups;
-              }
-            }
-            if (current.github) entries.push(current);
-
-            const match = entries.find((e) => e.github === prAuthor);
-            return Boolean(match && Array.isArray(match.groups) && match.groups.includes("*"));
+            const headRepo = pr?.head?.repo?.full_name;
+            const baseRepo = pr?.base?.repo?.full_name;
+            trusted = Boolean(headRepo && baseRepo && headRepo === baseRepo);
           }
-
-          core.setOutput("trusted", (await isTrusted()) ? "true" : "false");
+          core.setOutput("trusted", trusted ? "true" : "false");
 
     - uses: ./.github/actions/setup-nix
     - uses: ./.github/actions/setup-challenge-runtime

--- a/tools/pwnshop/src/pwnshop/commands/test.py
+++ b/tools/pwnshop/src/pwnshop/commands/test.py
@@ -58,6 +58,12 @@ def test_command(targets, modified_since, jobs, require_tests, test_timeout, log
             console.print(f"[yellow]No challenges found since {modified_since}[/]")
             return
         raise click.ClickException("No challenges found in provided targets.")
+
+    # In CI, avoid printing test stdout/stderr to the job log. Instead, write any failing
+    # test output to log files.
+    if log_failures is None and os.environ.get("GITHUB_ACTIONS", "").lower() in {"1", "true", "yes"}:
+        log_failures = pathlib.Path(os.environ.get("RUNNER_TEMP", "/tmp")) / "pwnshop-failures"
+
     jobs = jobs or os.cpu_count() or 1
     failed: dict[pathlib.Path, list] = {}
     passed_count = failed_count = total_tests = failed_tests = 0

--- a/tools/pwnshop/src/pwnshop/commands/test.py
+++ b/tools/pwnshop/src/pwnshop/commands/test.py
@@ -39,6 +39,7 @@ logger = logging.getLogger(__name__)
     type=click.Path(path_type=pathlib.Path, file_okay=False, resolve_path=True),
     help="Write failure output to DIR/challenge/test.log files.",
 )
+@click.option("--silent-failures", is_flag=True, help="Do not print failing test output to stdout/stderr.")
 @click.argument(
     "targets",
     nargs=-1,
@@ -51,7 +52,7 @@ logger = logging.getLogger(__name__)
         resolve_path=False,
     ),
 )
-def test_command(targets, modified_since, jobs, require_tests, test_timeout, log_failures):
+def test_command(targets, modified_since, jobs, require_tests, test_timeout, log_failures, silent_failures):
     """Test one or more challenges."""
     if not (challenge_paths := lib.resolve_targets(targets, modified_since=modified_since)):
         if modified_since:
@@ -151,7 +152,7 @@ def test_command(targets, modified_since, jobs, require_tests, test_timeout, log
                             log_file = log_failures / challenge / f"{test_path}.log"
                             log_file.parent.mkdir(parents=True, exist_ok=True)
                             log_file.write_text(output)
-                        else:
+                        elif not silent_failures:
                             console.print(output.rstrip("\n"), markup=False)
                 if challenge in failed:
                     failed_count += 1

--- a/tools/pwnshop/src/pwnshop/commands/test.py
+++ b/tools/pwnshop/src/pwnshop/commands/test.py
@@ -60,11 +60,6 @@ def test_command(targets, modified_since, jobs, require_tests, test_timeout, log
             return
         raise click.ClickException("No challenges found in provided targets.")
 
-    # In CI, avoid printing test stdout/stderr to the job log. Instead, write any failing
-    # test output to log files.
-    if log_failures is None and os.environ.get("GITHUB_ACTIONS", "").lower() in {"1", "true", "yes"}:
-        log_failures = pathlib.Path(os.environ.get("RUNNER_TEMP", "/tmp")) / "pwnshop-failures"
-
     jobs = jobs or os.cpu_count() or 1
     failed: dict[pathlib.Path, list] = {}
     passed_count = failed_count = total_tests = failed_tests = 0

--- a/tools/pwnshop/src/pwnshop/lib/__init__.py
+++ b/tools/pwnshop/src/pwnshop/lib/__init__.py
@@ -280,9 +280,9 @@ def list_challenges(directory: pathlib.Path, modified_since: Optional[str] = Non
         return challenges
 
     relative_lookup = {path.as_posix(): path for path in challenge_dirs}
-    logger.debug("filtering by git diff --name-only --relative %s", modified_since)
+    logger.debug("filtering by git diff --name-only --relative %s..HEAD", modified_since)
     diff_output = subprocess.check_output(
-        ["git", "diff", "--name-only", "--relative", modified_since],
+        ["git", "diff", "--name-only", "--relative", modified_since, "HEAD", "--", "."],
         cwd=directory,
         text=True,
     )

--- a/tools/pwnshop/src/pwnshop/lib/__init__.py
+++ b/tools/pwnshop/src/pwnshop/lib/__init__.py
@@ -280,9 +280,9 @@ def list_challenges(directory: pathlib.Path, modified_since: Optional[str] = Non
         return challenges
 
     relative_lookup = {path.as_posix(): path for path in challenge_dirs}
-    logger.debug("filtering by git diff --name-only --relative %s..HEAD", modified_since)
+    logger.debug("filtering by git diff --name-only --relative %s", modified_since)
     diff_output = subprocess.check_output(
-        ["git", "diff", "--name-only", "--relative", modified_since, "HEAD", "--", "."],
+        ["git", "diff", "--name-only", "--relative", modified_since],
         cwd=directory,
         text=True,
     )

--- a/tools/pwnshop/src/pwnshop/lib/__init__.py
+++ b/tools/pwnshop/src/pwnshop/lib/__init__.py
@@ -281,22 +281,10 @@ def list_challenges(directory: pathlib.Path, modified_since: Optional[str] = Non
 
     relative_lookup = {path.as_posix(): path for path in challenge_dirs}
     logger.debug("filtering by git diff --name-only --relative %s", modified_since)
-    # Use a commit-to-commit diff as the baseline to avoid being confused by later
-    # working tree mutations (e.g. CI deleting encrypted directories before testing).
-    # Then union with a working tree diff so local uncommitted changes are still included.
-    diff_output = "\n".join(
-        [
-            subprocess.check_output(
-                ["git", "diff", "--name-only", "--relative", modified_since, "HEAD", "--", "."],
-                cwd=directory,
-                text=True,
-            ),
-            subprocess.check_output(
-                ["git", "diff", "--name-only", "--relative", "HEAD", "--", "."],
-                cwd=directory,
-                text=True,
-            ),
-        ]
+    diff_output = subprocess.check_output(
+        ["git", "diff", "--name-only", "--relative", modified_since],
+        cwd=directory,
+        text=True,
     )
     affected = set()
     for line in diff_output.splitlines():


### PR DESCRIPTION
PR #83 changed many test cases, but CI can skip running them because `tests_private/` is encrypted and we remove encrypted files on untrusted runs.

This PR adds a trust gate so CI can unlock git-crypt (and run private tests) only on trusted events, while still ensuring encrypted files are removed on untrusted PRs. It also runs `pwnshop test --silent-failures` in CI to avoid printing failing test output into the job log.