### PR TITLE
ci: simplify git-crypt unlock

### DIFF
--- a/.github/actions/test-challenges/action.yml
+++ b/.github/actions/test-challenges/action.yml
@@ -26,23 +26,14 @@ runs:
         GPG_PRIVATE_KEY: ${{ inputs.gpg_private_key }}
         CHALLENGES_DIR: challenges/${{ inputs.challenges }}
       run: |
-        encrypted_paths_file="$(mktemp)"
-        git crypt status -e \
-          | sed -n 's/^[[:space:]]*encrypted:[[:space:]]*//p' \
-          | sort -u >"$encrypted_paths_file"
-
         if [ -n "$GPG_PRIVATE_KEY" ]; then
           printf '%s' "$GPG_PRIVATE_KEY" | gpg --batch --import
           git crypt unlock
-
-          while IFS= read -r encrypted_path; do
-            case "$encrypted_path" in
-              "$CHALLENGES_DIR"/*) ;;
-              *) rm -f "$encrypted_path" ;;
-            esac
-          done <"$encrypted_paths_file"
         else
-          xargs -r rm -f <"$encrypted_paths_file"
+          git crypt status -e \
+            | sed -n 's/^[[:space:]]*encrypted:[[:space:]]*//p' \
+            | sort -u \
+            | xargs -r rm -f
         fi
 
     - name: Test challenges

--- a/.github/actions/test-challenges/action.yml
+++ b/.github/actions/test-challenges/action.yml
@@ -26,24 +26,23 @@ runs:
         GPG_PRIVATE_KEY: ${{ inputs.gpg_private_key }}
         CHALLENGES_DIR: challenges/${{ inputs.challenges }}
       run: |
-        encrypted_paths() {
-          git crypt status -e \
-            | sed -n 's/^[[:space:]]*encrypted:[[:space:]]*//p' \
-            | sort -u
-        }
+        encrypted_paths_file="$(mktemp)"
+        git crypt status -e \
+          | sed -n 's/^[[:space:]]*encrypted:[[:space:]]*//p' \
+          | sort -u >"$encrypted_paths_file"
 
         if [ -n "$GPG_PRIVATE_KEY" ]; then
-          encrypted_paths | while IFS= read -r encrypted_path; do
+          printf '%s' "$GPG_PRIVATE_KEY" | gpg --batch --import
+          git crypt unlock
+
+          while IFS= read -r encrypted_path; do
             case "$encrypted_path" in
               "$CHALLENGES_DIR"/*) ;;
               *) rm -f "$encrypted_path" ;;
             esac
-          done
-
-          printf '%s' "$GPG_PRIVATE_KEY" | gpg --batch --import
-          git crypt unlock
+          done <"$encrypted_paths_file"
         else
-          encrypted_paths | xargs -r rm -f
+          xargs -r rm -f <"$encrypted_paths_file"
         fi
 
     - name: Test challenges


### PR DESCRIPTION
Fix `git-crypt unlock` failing with "Working directory not clean".

If a `gpg_private_key` is provided, we now just unlock (no pruning beforehand). If no key is provided, we delete all encrypted files reported by `git crypt status -e`.