### PR TITLE
pwnshop: ignore challenge init output

### DIFF
--- a/tools/pwnshop/src/pwnshop/lib/__init__.py
+++ b/tools/pwnshop/src/pwnshop/lib/__init__.py
@@ -211,7 +211,13 @@ def run_challenge(
         check=True,
     )
     logger.debug("flag written to /flag")
-    subprocess.check_call(
+    # Many challenges start background services in `.init` (e.g. Flask) which can be noisy.
+    # Redirect `.init` output to a file inside the container so CI stays clean.
+    #
+    # Note: piping `docker exec` output to the host can cause backgrounded services to inherit
+    # a pipe and later die or block when the pipe closes/fills. A file avoids that.
+    init_log = "/tmp/pwnshop-init.log"
+    init_run = subprocess.run(
         [
             "docker",
             "exec",
@@ -219,10 +225,36 @@ def run_challenge(
             container,
             "/bin/sh",
             "-c",
-            "[ ! -e /challenge/.init ] || /challenge/.init",
-        ]
+            (
+                f"rm -f {init_log}; "
+                "if [ -e /challenge/.init ]; then "
+                f"/challenge/.init >{init_log} 2>&1; "
+                "fi"
+            ),
+        ],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        text=True,
     )
-    logger.debug(".init completed (if present)")
+    if init_run.returncode != 0:
+        init_out = subprocess.run(
+            ["docker", "exec", "--user=0:0", container, "/bin/sh", "-c", f"cat {init_log} 2>/dev/null || true"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        ).stdout
+        raise RuntimeError(f"Challenge init failed for {challenge_path} (rc={init_run.returncode}).\n{init_out or ''}")
+    if logger.isEnabledFor(logging.DEBUG):
+        init_out = subprocess.run(
+            ["docker", "exec", "--user=0:0", container, "/bin/sh", "-c", f"cat {init_log} 2>/dev/null || true"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        ).stdout
+        if init_out:
+            logger.debug(".init output for %s:\n%s", challenge_path, init_out.rstrip("\n"))
+        else:
+            logger.debug(".init completed (if present)")
     try:
         yield container, flag
     finally:

--- a/tools/pwnshop/src/pwnshop/lib/__init__.py
+++ b/tools/pwnshop/src/pwnshop/lib/__init__.py
@@ -225,6 +225,7 @@ def run_challenge(
         stderr=subprocess.DEVNULL,
         check=True,
     )
+    logger.debug(".init completed (if present)")
     try:
         yield container, flag
     finally:

--- a/tools/pwnshop/src/pwnshop/lib/__init__.py
+++ b/tools/pwnshop/src/pwnshop/lib/__init__.py
@@ -211,13 +211,7 @@ def run_challenge(
         check=True,
     )
     logger.debug("flag written to /flag")
-    # Many challenges start background services in `.init` (e.g. Flask) which can be noisy.
-    # Redirect `.init` output to a file inside the container so CI stays clean.
-    #
-    # Note: piping `docker exec` output to the host can cause backgrounded services to inherit
-    # a pipe and later die or block when the pipe closes/fills. A file avoids that.
-    init_log = "/tmp/pwnshop-init.log"
-    init_run = subprocess.run(
+    subprocess.run(
         [
             "docker",
             "exec",
@@ -225,36 +219,12 @@ def run_challenge(
             container,
             "/bin/sh",
             "-c",
-            (
-                f"rm -f {init_log}; "
-                "if [ -e /challenge/.init ]; then "
-                f"/challenge/.init >{init_log} 2>&1; "
-                "fi"
-            ),
+            "[ ! -e /challenge/.init ] || /challenge/.init",
         ],
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
-        text=True,
+        check=True,
     )
-    if init_run.returncode != 0:
-        init_out = subprocess.run(
-            ["docker", "exec", "--user=0:0", container, "/bin/sh", "-c", f"cat {init_log} 2>/dev/null || true"],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            text=True,
-        ).stdout
-        raise RuntimeError(f"Challenge init failed for {challenge_path} (rc={init_run.returncode}).\n{init_out or ''}")
-    if logger.isEnabledFor(logging.DEBUG):
-        init_out = subprocess.run(
-            ["docker", "exec", "--user=0:0", container, "/bin/sh", "-c", f"cat {init_log} 2>/dev/null || true"],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            text=True,
-        ).stdout
-        if init_out:
-            logger.debug(".init output for %s:\n%s", challenge_path, init_out.rstrip("\n"))
-        else:
-            logger.debug(".init completed (if present)")
     try:
         yield container, flag
     finally:


### PR DESCRIPTION
pwnshop test runs /challenge/.init inside containers, and some challenges print noisy startup banners (e.g. Flask/Werkzeug).

Silence .init stdout/stderr during tests so CI logs stay clean.