### PR TITLE
ci: fix publish blob location

### DIFF
--- a/.github/workflows/explore-publish-blobs.yml
+++ b/.github/workflows/explore-publish-blobs.yml
@@ -1,114 +1,90 @@
-name: Explore Publish Blobs
+name: Explore Containerd Blobs
 
 on:
   workflow_dispatch:
     inputs:
-      challenge_group:
-        description: Top-level challenge group to build (e.g. advent-of-pwn, web-security).
+      challenge:
+        description: Challenge to build (group/slug, e.g. sql-playground/sql-where).
         required: true
-        default: advent-of-pwn
-      r2_bucket_name:
-        description: R2 bucket used by publish-challenges (should usually stay as-is).
-        required: true
-        default: challenges-registry
+        default: sql-playground/sql-where
 
 jobs:
   explore:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: ./.github/actions/setup-nix
-      - uses: ./.github/actions/setup-challenge-runtime
+      - name: Install Nix (no cache action)
+        uses: DeterminateSystems/determinate-nix-action@v3.14.0
+        with:
+          extra-conf: |
+            accept-flake-config = true
+
+      - name: Setup challenge runtime mountpoint
+        shell: bash -euo pipefail {0}
+        run: |
+          sudo mkdir -p /mnt/pwn.college
+          sudo ln -sfn /mnt/pwn.college /var/lib/pwn.college
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
           cache-dependency-glob: tools/dojo/**
 
-      - name: Build/test challenge images
-        uses: ./.github/actions/test-challenges
-        with:
-          challenges: ${{ inputs.challenge_group }}
-          modified_since_ref: ""
-          gpg_private_key: ${{ secrets.GPG_ROOT_PRIVATE_KEY }}
-
-      - name: Install rclone
-        run: sudo apt-get update && sudo apt-get install -y rclone
-
-      - name: Explore local blob staging and remote location
+      - name: Build 1 challenge and locate containerd sha256 blobs on disk
         shell: 'nix develop -c bash -euo pipefail {0}'
-        env:
-          R2_BUCKET_NAME: ${{ inputs.r2_bucket_name }}
-          RCLONE_CONFIG_R2_TYPE: s3
-          RCLONE_CONFIG_R2_PROVIDER: Cloudflare
-          RCLONE_CONFIG_R2_ENDPOINT: https://${{ secrets.R2_ACCOUNT_ID }}.r2.cloudflarestorage.com
-          RCLONE_CONFIG_R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY }}
-          RCLONE_CONFIG_R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_KEY }}
         run: |
+          echo "::group::Runtime + docker daemon"
+          echo "DOCKER_HOST=${DOCKER_HOST:-<unset>}"
+          for i in $(seq 1 60); do
+            docker info >/dev/null 2>&1 && break
+            sleep 1
+          done
+          docker info --format 'DockerRootDir={{.DockerRootDir}} Driver={{.Driver}}' || (docker info || true)
+          echo "::endgroup::"
+
+          echo "::group::Manage encrypted files (no key in this workflow)"
+          # Match test-challenges behavior when no GPG key is available: delete encrypted tracked files.
+          git crypt status -e \
+            | sed -n 's/^[[:space:]]*encrypted:[[:space:]]*//p' \
+            | sort -u \
+            | xargs -r rm -f
+          echo "::endgroup::"
+
+          echo "::group::Build one challenge"
+          challenge_dir="challenges/${{ inputs.challenge }}"
+          echo "challenge_dir=$challenge_dir"
+          image_id="$(./pwnshop build "$challenge_dir" | tail -n 1)"
+          echo "image_id=$image_id"
+          echo "::endgroup::"
+
           docker_root_dir="$(docker info --format '{{.DockerRootDir}}')"
           containerd_blobs_dir="$docker_root_dir/containerd/daemon/io.containerd.content.v1.content/blobs"
 
-          echo "::group::Docker/containerd paths"
+          echo "::group::Containerd content store (expected location)"
           echo "docker_root_dir=$docker_root_dir"
+          echo "docker_root_dir_real=$(readlink -f "$docker_root_dir" || echo "$docker_root_dir")"
           echo "containerd_blobs_dir=$containerd_blobs_dir"
-          echo "containerd_blobs_dir_dev=$(stat -c %d "$containerd_blobs_dir")"
-          df -T "$docker_root_dir" "$containerd_blobs_dir" || true
+          echo "containerd_blobs_dir_real=$(readlink -f "$containerd_blobs_dir" || echo "$containerd_blobs_dir")"
+          sudo ls -la "$containerd_blobs_dir/sha256" | head -n 50 || true
           echo "::endgroup::"
 
-          echo "::group::Remote top-level prefixes"
-          rclone lsf "r2:${R2_BUCKET_NAME}" --dirs-only --config /dev/null || true
+          echo "::group::Verify at least one sha256 blob exists on disk for the built image"
+          mapfile -t layers < <(docker image inspect "$image_id" --format '{{range .RootFS.Layers}}{{println .}}{{end}}')
+          echo "layer_count=${#layers[@]}"
+          for digest in "${layers[@]:0:5}"; do
+            digest_path="${digest//:/\/}"
+            blob_path="$containerd_blobs_dir/$digest_path"
+            echo "digest=$digest"
+            echo "blob_path=$blob_path"
+            echo "blob_path_real=$(sudo readlink -f "$blob_path" 2>/dev/null || echo "<missing>")"
+            sudo test -f "$blob_path" || continue
+            sudo stat -c 'FOUND %n (%s bytes)' "$blob_path"
+            sudo ls -l "$blob_path"
+            # Stop after the first confirmed blob.
+            break
+          done
           echo "::endgroup::"
 
-          echo "::group::Local image inventory"
-          echo "image_count=$(docker image ls --filter \"label=pwncollege.challenge\" --quiet | wc -l)"
-          docker image ls --filter "label=pwncollege.challenge" --no-trunc --format '{{.ID}} {{.Repository}}:{{.Tag}}' | head -n 50 || true
-          echo "::endgroup::"
-
-          publish_blobs_dir="$docker_root_dir/publish-explore/blobs"
-          publish_manifests_dir="$docker_root_dir/publish-explore/manifests"
-          sudo mkdir -p "$publish_blobs_dir" "$publish_manifests_dir"
-
-          while IFS= read -r line; do
-            image_id="${line%% *}"
-            challenge_slug="${line#* }"
-            stack=("$image_id")
-            while ((${#stack[@]})); do
-              digest="${stack[-1]}"
-              digest_path="${digest//:/\/}"
-              unset 'stack[-1]'
-              sudo mkdir -p "$publish_blobs_dir/${digest_path%%/*}"
-              if ! sudo ln "$containerd_blobs_dir/$digest_path" "$publish_blobs_dir/$digest_path" 2>ln.err; then
-                echo "hardlink failed for $digest_path: $(cat ln.err)" >&2
-                # Fallback to a real copy so we can continue exploring even if hardlinks are unavailable.
-                sudo cp --reflink=auto "$containerd_blobs_dir/$digest_path" "$publish_blobs_dir/$digest_path" 2>/dev/null || true
-              fi
-              rm -f ln.err
-              mapfile -t -O "${#stack[@]}" stack < <(
-                sudo jq -r '.manifests[]?.digest,.config.digest?,.layers[]?.digest? | select(type=="string")' \
-                  "$containerd_blobs_dir/$digest_path" 2>/dev/null
-              )
-            done
-            sudo mkdir -p "$publish_manifests_dir/$challenge_slug"
-            printf '%s\n' "$image_id" | sudo tee "$publish_manifests_dir/$challenge_slug/latest" >/dev/null
-          done < <(
-            docker image ls --filter "label=pwncollege.challenge" --no-trunc --quiet \
-              | xargs -r docker image inspect --format '{{.Id}} {{index .Config.Labels "pwncollege.challenge"}}'
-          )
-
-          echo "::group::Local publish stats"
-          echo "blob_file_count=$(sudo find \"$publish_blobs_dir\" -type f | wc -l)"
-          sudo du -sh "$publish_blobs_dir" "$publish_manifests_dir" || true
-          first_blob_rel="$(sudo find "$publish_blobs_dir" -type f -print -quit | sed "s#^$publish_blobs_dir/##" || true)"
-          echo "first_blob_rel=$first_blob_rel"
-          echo "::endgroup::"
-
-          echo "::group::Remote existence checks (one sample blob)"
-          if [ -n "$first_blob_rel" ]; then
-            # Expected location.
-            rclone lsjson "r2:${R2_BUCKET_NAME}/blobs/$first_blob_rel" --config /dev/null || true
-            # Common misprefixes (in case blobs are being written somewhere unexpected).
-            rclone lsjson "r2:${R2_BUCKET_NAME}/$first_blob_rel" --config /dev/null || true
-            rclone lsjson "r2:${R2_BUCKET_NAME}/v2/blobs/$first_blob_rel" --config /dev/null || true
-            rclone lsjson "r2:${R2_BUCKET_NAME}/oci/blobs/$first_blob_rel" --config /dev/null || true
-          fi
+          echo "::group::Fallback: find some sha256 blobs under docker root"
+          sudo find "$docker_root_dir/containerd" -type f -path '*/io.containerd.content.v1.content/blobs/sha256/*' -printf '%p\n' 2>/dev/null | head -n 20 || true
           echo "::endgroup::"

--- a/.github/workflows/explore-publish-blobs.yml
+++ b/.github/workflows/explore-publish-blobs.yml
@@ -1,0 +1,114 @@
+name: Explore Publish Blobs
+
+on:
+  workflow_dispatch:
+    inputs:
+      challenge_group:
+        description: Top-level challenge group to build (e.g. advent-of-pwn, web-security).
+        required: true
+        default: advent-of-pwn
+      r2_bucket_name:
+        description: R2 bucket used by publish-challenges (should usually stay as-is).
+        required: true
+        default: challenges-registry
+
+jobs:
+  explore:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-nix
+      - uses: ./.github/actions/setup-challenge-runtime
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          cache-dependency-glob: tools/dojo/**
+
+      - name: Build/test challenge images
+        uses: ./.github/actions/test-challenges
+        with:
+          challenges: ${{ inputs.challenge_group }}
+          modified_since_ref: ""
+          gpg_private_key: ${{ secrets.GPG_ROOT_PRIVATE_KEY }}
+
+      - name: Install rclone
+        run: sudo apt-get update && sudo apt-get install -y rclone
+
+      - name: Explore local blob staging and remote location
+        shell: 'nix develop -c bash -euo pipefail {0}'
+        env:
+          R2_BUCKET_NAME: ${{ inputs.r2_bucket_name }}
+          RCLONE_CONFIG_R2_TYPE: s3
+          RCLONE_CONFIG_R2_PROVIDER: Cloudflare
+          RCLONE_CONFIG_R2_ENDPOINT: https://${{ secrets.R2_ACCOUNT_ID }}.r2.cloudflarestorage.com
+          RCLONE_CONFIG_R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY }}
+          RCLONE_CONFIG_R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_KEY }}
+        run: |
+          docker_root_dir="$(docker info --format '{{.DockerRootDir}}')"
+          containerd_blobs_dir="$docker_root_dir/containerd/daemon/io.containerd.content.v1.content/blobs"
+
+          echo "::group::Docker/containerd paths"
+          echo "docker_root_dir=$docker_root_dir"
+          echo "containerd_blobs_dir=$containerd_blobs_dir"
+          echo "containerd_blobs_dir_dev=$(stat -c %d "$containerd_blobs_dir")"
+          df -T "$docker_root_dir" "$containerd_blobs_dir" || true
+          echo "::endgroup::"
+
+          echo "::group::Remote top-level prefixes"
+          rclone lsf "r2:${R2_BUCKET_NAME}" --dirs-only --config /dev/null || true
+          echo "::endgroup::"
+
+          echo "::group::Local image inventory"
+          echo "image_count=$(docker image ls --filter \"label=pwncollege.challenge\" --quiet | wc -l)"
+          docker image ls --filter "label=pwncollege.challenge" --no-trunc --format '{{.ID}} {{.Repository}}:{{.Tag}}' | head -n 50 || true
+          echo "::endgroup::"
+
+          publish_blobs_dir="$docker_root_dir/publish-explore/blobs"
+          publish_manifests_dir="$docker_root_dir/publish-explore/manifests"
+          sudo mkdir -p "$publish_blobs_dir" "$publish_manifests_dir"
+
+          while IFS= read -r line; do
+            image_id="${line%% *}"
+            challenge_slug="${line#* }"
+            stack=("$image_id")
+            while ((${#stack[@]})); do
+              digest="${stack[-1]}"
+              digest_path="${digest//:/\/}"
+              unset 'stack[-1]'
+              sudo mkdir -p "$publish_blobs_dir/${digest_path%%/*}"
+              if ! sudo ln "$containerd_blobs_dir/$digest_path" "$publish_blobs_dir/$digest_path" 2>ln.err; then
+                echo "hardlink failed for $digest_path: $(cat ln.err)" >&2
+                # Fallback to a real copy so we can continue exploring even if hardlinks are unavailable.
+                sudo cp --reflink=auto "$containerd_blobs_dir/$digest_path" "$publish_blobs_dir/$digest_path" 2>/dev/null || true
+              fi
+              rm -f ln.err
+              mapfile -t -O "${#stack[@]}" stack < <(
+                sudo jq -r '.manifests[]?.digest,.config.digest?,.layers[]?.digest? | select(type=="string")' \
+                  "$containerd_blobs_dir/$digest_path" 2>/dev/null
+              )
+            done
+            sudo mkdir -p "$publish_manifests_dir/$challenge_slug"
+            printf '%s\n' "$image_id" | sudo tee "$publish_manifests_dir/$challenge_slug/latest" >/dev/null
+          done < <(
+            docker image ls --filter "label=pwncollege.challenge" --no-trunc --quiet \
+              | xargs -r docker image inspect --format '{{.Id}} {{index .Config.Labels "pwncollege.challenge"}}'
+          )
+
+          echo "::group::Local publish stats"
+          echo "blob_file_count=$(sudo find \"$publish_blobs_dir\" -type f | wc -l)"
+          sudo du -sh "$publish_blobs_dir" "$publish_manifests_dir" || true
+          first_blob_rel="$(sudo find "$publish_blobs_dir" -type f -print -quit | sed "s#^$publish_blobs_dir/##" || true)"
+          echo "first_blob_rel=$first_blob_rel"
+          echo "::endgroup::"
+
+          echo "::group::Remote existence checks (one sample blob)"
+          if [ -n "$first_blob_rel" ]; then
+            # Expected location.
+            rclone lsjson "r2:${R2_BUCKET_NAME}/blobs/$first_blob_rel" --config /dev/null || true
+            # Common misprefixes (in case blobs are being written somewhere unexpected).
+            rclone lsjson "r2:${R2_BUCKET_NAME}/$first_blob_rel" --config /dev/null || true
+            rclone lsjson "r2:${R2_BUCKET_NAME}/v2/blobs/$first_blob_rel" --config /dev/null || true
+            rclone lsjson "r2:${R2_BUCKET_NAME}/oci/blobs/$first_blob_rel" --config /dev/null || true
+          fi
+          echo "::endgroup::"

--- a/.github/workflows/publish-challenges.yml
+++ b/.github/workflows/publish-challenges.yml
@@ -5,10 +5,10 @@ on:
     branches: [ main ]
   workflow_dispatch:
     inputs:
-      challenge_target:
-        description: "Path to a single challenge (or a folder of challenges) to build for exploration, e.g. challenges/advent-of-pwn/2025/day-01."
+      image_ref:
+        description: "Image to pull for on-runner blob location exploration (e.g. busybox:latest, alpine:latest)."
         required: true
-        default: challenges/advent-of-pwn/2025/day-01
+        default: busybox:latest
       explore_only:
         description: "Run exploration only (no rclone copy)."
         type: boolean
@@ -25,31 +25,32 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: ./.github/actions/setup-nix
-    - uses: ./.github/actions/setup-challenge-runtime
 
-    - name: Build challenge image(s)
-      id: build
-      shell: 'nix develop -c bash -euo pipefail {0}'
+    - name: Pull image
+      id: pull
+      shell: bash -euo pipefail {0}
       env:
-        CHALLENGE_TARGET: ${{ inputs.challenge_target }}
-        GPG_PRIVATE_KEY: ${{ secrets.GPG_ROOT_PRIVATE_KEY }}
+        IMAGE_REF: ${{ inputs.image_ref }}
       run: |
-        # Some targets include git-crypt'd tests; import key so builds that need them can proceed.
-        if [ -n "${GPG_PRIVATE_KEY:-}" ]; then
-          printf '%s' "$GPG_PRIVATE_KEY" | gpg --batch --import
-          git crypt unlock || true
-        fi
-        image_id="$(./pwnshop build "$CHALLENGE_TARGET" | tail -n 1)"
-        echo "Built image: $image_id"
+        docker pull "$IMAGE_REF"
+        image_id="$(docker image inspect --format '{{.Id}}' "$IMAGE_REF")"
+        repo_digest="$(docker image inspect --format '{{index .RepoDigests 0}}' "$IMAGE_REF" 2>/dev/null || true)"
+        echo "Pulled image: $IMAGE_REF"
+        echo "image_id=$image_id"
+        echo "repo_digest=$repo_digest"
         echo "image_id=$image_id" >>"$GITHUB_OUTPUT"
 
     - name: Explore blob locations on disk
-      shell: 'nix develop -c bash -euo pipefail {0}'
+      shell: bash -euo pipefail {0}
       env:
-        IMAGE_ID: ${{ steps.build.outputs.image_id }}
+        IMAGE_ID: ${{ steps.pull.outputs.image_id }}
+        IMAGE_REF: ${{ inputs.image_ref }}
       run: |
         docker_root_dir="$(docker info --format '{{.DockerRootDir}}')"
+        echo "::group::Inputs"
+        echo "image_ref=$IMAGE_REF"
+        echo "image_id=$IMAGE_ID"
+        echo "::endgroup::"
 
         echo "::group::Docker info"
         echo "docker_root_dir=$docker_root_dir"
@@ -62,29 +63,48 @@ jobs:
           exit 1
         fi
 
-        sha="${image_id#sha256:}"
-        if [ "$sha" = "$image_id" ]; then
+        sha_config="${image_id#sha256:}"
+        if [ "$sha_config" = "$image_id" ]; then
           echo "unexpected image id format: $image_id" >&2
           exit 1
         fi
 
-        echo "::group::Locate $image_id under DockerRootDir"
-        echo "sha=$sha"
+        # RepoDigests exist for pulled images; the digest portion may also exist in the on-disk blob stores.
+        repo_digest="$(docker image inspect --format '{{index .RepoDigests 0}}' "$IMAGE_REF" 2>/dev/null || true)"
+        sha_manifest=""
+        if [[ "$repo_digest" == *@sha256:* ]]; then
+          sha_manifest="${repo_digest##*@sha256:}"
+        fi
+
+        echo "::group::Locate sha256 objects under DockerRootDir"
+        echo "sha_config=$sha_config"
+        echo "repo_digest=$repo_digest"
+        echo "sha_manifest=$sha_manifest"
 
         # Common storage locations across Docker/BuildKit/containerd setups.
         candidates=(
-          "$docker_root_dir/image/overlay2/imagedb/content/sha256/$sha"
-          "$docker_root_dir/buildkit/content/blobs/sha256/$sha"
-          "$docker_root_dir/containerd/daemon/io.containerd.content.v1.content/blobs/sha256/$sha"
+          "$docker_root_dir/image/overlay2/imagedb/content/sha256/$sha_config"
+          "$docker_root_dir/buildkit/content/blobs/sha256/$sha_config"
+          "$docker_root_dir/containerd/daemon/io.containerd.content.v1.content/blobs/sha256/$sha_config"
         )
+        if [ -n "$sha_manifest" ]; then
+          candidates+=(
+            "$docker_root_dir/buildkit/content/blobs/sha256/$sha_manifest"
+            "$docker_root_dir/containerd/daemon/io.containerd.content.v1.content/blobs/sha256/$sha_manifest"
+          )
+        fi
 
         for p in "${candidates[@]}"; do
           echo "--- $p"
           sudo ls -la "$p" 2>&1 || true
         done
 
-        echo "--- find $docker_root_dir -path '*/sha256/$sha'"
-        sudo find "$docker_root_dir" -maxdepth 8 -type f -path "*/sha256/$sha" -print 2>/dev/null | head -n 50 || true
+        echo "--- find $docker_root_dir -path '*/sha256/<digest>' (config)"
+        sudo find "$docker_root_dir" -maxdepth 10 -type f -path "*/sha256/$sha_config" -print 2>/dev/null | head -n 50 || true
+        if [ -n "$sha_manifest" ]; then
+          echo "--- find $docker_root_dir -path '*/sha256/<digest>' (manifest)"
+          sudo find "$docker_root_dir" -maxdepth 10 -type f -path "*/sha256/$sha_manifest" -print 2>/dev/null | head -n 50 || true
+        fi
         echo "::endgroup::"
 
         if [ "${{ inputs.explore_only }}" = "true" ]; then

--- a/.github/workflows/publish-challenges.yml
+++ b/.github/workflows/publish-challenges.yml
@@ -41,8 +41,8 @@ jobs:
         fi
         ./pwnshop build "$CHALLENGE_TARGET"
 
-    - name: Install rclone
-      run: sudo apt-get update && sudo apt-get install -y rclone
+    - name: Install rclone + skopeo
+      run: sudo apt-get update && sudo apt-get install -y rclone skopeo
 
     - name: Explore local blob staging and remote location
       shell: 'nix develop -c bash -euo pipefail {0}'
@@ -55,54 +55,54 @@ jobs:
         RCLONE_CONFIG_R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_KEY }}
       run: |
         docker_root_dir="$(docker info --format '{{.DockerRootDir}}')"
-        containerd_blobs_dir="$docker_root_dir/containerd/daemon/io.containerd.content.v1.content/blobs"
 
-        echo "::group::Docker/containerd paths"
+        echo "::group::Docker info"
         echo "docker_root_dir=$docker_root_dir"
-        echo "containerd_blobs_dir=$containerd_blobs_dir"
-        echo "containerd_blobs_dir_dev=$(stat -c %d "$containerd_blobs_dir")"
-        df -T "$docker_root_dir" "$containerd_blobs_dir" || true
+        docker info --format 'Driver={{.Driver}} RootDir={{.DockerRootDir}}'
         echo "::endgroup::"
 
         echo "::group::Remote top-level prefixes"
         rclone lsf "r2:${R2_BUCKET_NAME}" --dirs-only --config /dev/null || true
         echo "::endgroup::"
 
-        publish_blobs_dir="$docker_root_dir/publish-explore/blobs"
-        publish_manifests_dir="$docker_root_dir/publish-explore/manifests"
-        sudo mkdir -p "$publish_blobs_dir" "$publish_manifests_dir"
+        publish_root="/mnt/pwn.college/publish-explore"
+        publish_blobs_dir="$publish_root/blobs"
+        publish_manifests_dir="$publish_root/manifests"
+        oci_root="$publish_root/oci"
+        sudo mkdir -p "$publish_root"
+        sudo chown -R "$(id -u):$(id -g)" "$publish_root"
+        mkdir -p "$publish_blobs_dir" "$publish_manifests_dir" "$oci_root"
 
         while IFS= read -r line; do
           image_id="${line%% *}"
           challenge_slug="${line#* }"
-          stack=("$image_id")
-          while ((${#stack[@]})); do
-            digest="${stack[-1]}"
-            digest_path="${digest//:/\/}"
-            unset 'stack[-1]'
-            sudo mkdir -p "$publish_blobs_dir/${digest_path%%/*}"
-            if ! sudo ln "$containerd_blobs_dir/$digest_path" "$publish_blobs_dir/$digest_path" 2>ln.err; then
-              echo "hardlink failed for $digest_path: $(cat ln.err)" >&2
-              # Keep exploring even if hardlinks are unavailable.
-              sudo cp --reflink=auto "$containerd_blobs_dir/$digest_path" "$publish_blobs_dir/$digest_path" 2>/dev/null || true
-            fi
-            rm -f ln.err
-            mapfile -t -O "${#stack[@]}" stack < <(
-              sudo jq -r '.manifests[]?.digest,.config.digest?,.layers[]?.digest? | select(type=="string")' \
-                "$containerd_blobs_dir/$digest_path" 2>/dev/null
-            )
-          done
-          sudo mkdir -p "$publish_manifests_dir/$challenge_slug"
-          printf '%s\n' "$image_id" | sudo tee "$publish_manifests_dir/$challenge_slug/latest" >/dev/null
+          image_tag="pwncollege-challenge:${challenge_slug//\//-}"
+          docker tag "$image_id" "$image_tag"
+
+          image_oci_dir="$oci_root/$challenge_slug"
+          mkdir -p "$image_oci_dir"
+
+          skopeo copy --insecure-policy "docker-daemon:$image_tag" "oci:$image_oci_dir:latest"
+          manifest_ref="$(jq -r '.manifests[0].digest' "$image_oci_dir/index.json")"
+          if [ -z "$manifest_ref" ] || [ "$manifest_ref" = "null" ]; then
+            echo "failed to resolve manifest digest for $challenge_slug (image_id=$image_id)" >&2
+            exit 1
+          fi
+
+          mkdir -p "$publish_manifests_dir/$challenge_slug"
+          printf '%s\n' "$manifest_ref" >"$publish_manifests_dir/$challenge_slug/latest"
+
+          cp -a -n "$image_oci_dir/blobs/." "$publish_blobs_dir/"
         done < <(
           docker image ls --filter "label=pwncollege.challenge" --no-trunc --quiet \
             | xargs -r docker image inspect --format '{{.Id}} {{index .Config.Labels "pwncollege.challenge"}}'
         )
 
         echo "::group::Local publish stats"
-        echo "blob_file_count=$(sudo find \"$publish_blobs_dir\" -type f | wc -l)"
-        sudo du -sh "$publish_blobs_dir" "$publish_manifests_dir" || true
-        first_blob_rel="$(sudo find "$publish_blobs_dir" -type f -print -quit | sed "s#^$publish_blobs_dir/##" || true)"
+        blob_file_count="$(find "$publish_blobs_dir" -type f | wc -l)"
+        echo "blob_file_count=$blob_file_count"
+        du -sh "$publish_blobs_dir" "$publish_manifests_dir" || true
+        first_blob_rel="$(find "$publish_blobs_dir" -type f -print -quit | sed "s#^$publish_blobs_dir/##" || true)"
         echo "first_blob_rel=$first_blob_rel"
         echo "::endgroup::"
 
@@ -167,8 +167,8 @@ jobs:
         modified_since_ref: ""
         gpg_private_key: ${{ secrets.GPG_ROOT_PRIVATE_KEY }}
 
-    - name: Install rclone
-      run: sudo apt-get update && sudo apt-get install -y rclone
+    - name: Install rclone + skopeo
+      run: sudo apt-get update && sudo apt-get install -y rclone skopeo
 
     - name: Publish challenges
       shell: 'nix develop -c bash -euo pipefail {0}'
@@ -181,29 +181,36 @@ jobs:
         RCLONE_CONFIG_R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY }}
         RCLONE_CONFIG_R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_KEY }}
       run: |
-        docker_root_dir="$(docker info --format '{{.DockerRootDir}}')"
-        containerd_blobs_dir="$docker_root_dir/containerd/daemon/io.containerd.content.v1.content/blobs"
-        # Keep the publish staging area on the same filesystem as the containerd content store so we can hardlink blobs.
-        publish_blobs_dir="$docker_root_dir/publish/blobs"
-        publish_manifests_dir="$docker_root_dir/publish/manifests"
-        sudo mkdir -p "$publish_blobs_dir" "$publish_manifests_dir"
+        publish_root="/mnt/pwn.college/publish"
+        publish_blobs_dir="$publish_root/blobs"
+        publish_manifests_dir="$publish_root/manifests"
+        oci_root="$publish_root/oci"
+        sudo mkdir -p "$publish_blobs_dir" "$publish_manifests_dir" "$oci_root"
+        sudo chown -R "$(id -u):$(id -g)" "$publish_root"
         while IFS= read -r line; do
           image_id="${line%% *}"
           challenge_slug="${line#* }"
-          stack=("$image_id")
-          while ((${#stack[@]})); do
-            digest="${stack[-1]}"
-            digest_path="${digest//:/\/}"
-            unset 'stack[-1]'
-            sudo mkdir -p "$publish_blobs_dir/${digest_path%%/*}"
-            sudo ln "$containerd_blobs_dir/$digest_path" "$publish_blobs_dir/$digest_path" 2>/dev/null || continue
-            mapfile -t -O "${#stack[@]}" stack < <(
-              sudo jq -r '.manifests[]?.digest,.config.digest?,.layers[]?.digest? | select(type=="string")' \
-                "$containerd_blobs_dir/$digest_path" 2>/dev/null
-            )
-          done
+
+          image_tag="pwncollege-challenge:${challenge_slug//\//-}"
+          docker tag "$image_id" "$image_tag"
+
+          image_oci_dir="$oci_root/$challenge_slug"
+          mkdir -p "$image_oci_dir"
+
+          # Export into an OCI layout so we can upload a static registry (blobs/ + tag pointers in manifests/).
+          skopeo copy --insecure-policy "docker-daemon:$image_tag" "oci:$image_oci_dir:latest"
+
+          manifest_ref="$(jq -r '.manifests[0].digest' "$image_oci_dir/index.json")"
+          if [ -z "$manifest_ref" ] || [ "$manifest_ref" = "null" ]; then
+            echo "failed to resolve manifest digest for $challenge_slug (image_id=$image_id)" >&2
+            exit 1
+          fi
+
+          # Deduplicate blobs across all exported images.
+          cp -a -n "$image_oci_dir/blobs/." "$publish_blobs_dir/"
+
           sudo mkdir -p "$publish_manifests_dir/$challenge_slug"
-          printf '%s\n' "$image_id" | sudo tee "$publish_manifests_dir/$challenge_slug/latest" >/dev/null
+          printf '%s\n' "$manifest_ref" | sudo tee "$publish_manifests_dir/$challenge_slug/latest" >/dev/null
         done < <(
           docker image ls --filter "label=pwncollege.challenge" --no-trunc --quiet \
             | xargs -r docker image inspect --format '{{.Id}} {{index .Config.Labels "pwncollege.challenge"}}'

--- a/.github/workflows/publish-challenges.yml
+++ b/.github/workflows/publish-challenges.yml
@@ -69,23 +69,46 @@ jobs:
         echo "::endgroup::"
 
         docker_root_dir="$(docker info --format '{{.DockerRootDir}}')"
-        containerd_blobs_dir="$docker_root_dir/containerd/daemon/io.containerd.content.v1.content/blobs"
 
-        echo "::group::Containerd content store (expected location)"
+        echo "::group::Locate containerd content store root"
         echo "docker_root_dir=$docker_root_dir"
         echo "docker_root_dir_real=$(readlink -f "$docker_root_dir" || echo "$docker_root_dir")"
-        echo "containerd_blobs_dir=$containerd_blobs_dir"
-        echo "containerd_blobs_dir_real=$(readlink -f "$containerd_blobs_dir" || echo "$containerd_blobs_dir")"
-        sudo ls -la "$containerd_blobs_dir/sha256" | head -n 40 || true
+        content_dir=""
+        for d in \
+          "$docker_root_dir/containerd/daemon/io.containerd.content.v1.content" \
+          "$docker_root_dir/containerd/io.containerd.content.v1.content"
+        do
+          if sudo test -d "$d"; then
+            content_dir="$d"
+            break
+          fi
+        done
+        if [ -z "$content_dir" ]; then
+          content_dir="$(sudo find "$docker_root_dir" -maxdepth 6 -type d -name io.containerd.content.v1.content -print -quit 2>/dev/null || true)"
+        fi
+        echo "content_dir=${content_dir:-<not found>}"
+        if [ -n "$content_dir" ]; then
+          echo "content_dir_real=$(sudo readlink -f "$content_dir" 2>/dev/null || echo "$content_dir")"
+          content_blobs_dir="$content_dir/blobs"
+          echo "content_blobs_dir=$content_blobs_dir"
+          sudo ls -la "$content_blobs_dir" | head -n 80 || true
+          sudo ls -la "$content_blobs_dir/sha256" | head -n 80 || true
+        fi
         echo "::endgroup::"
 
         echo "::group::Verify at least one sha256 blob exists on disk for the built image"
+        if [ -z "${content_dir:-}" ]; then
+          echo "ERROR: could not locate io.containerd.content.v1.content under docker_root_dir=$docker_root_dir" >&2
+          sudo find "$docker_root_dir" -maxdepth 6 -type d -name containerd -o -name blobs -o -name io.containerd.content.v1.content 2>/dev/null | head -n 200 || true
+          exit 1
+        fi
+
         mapfile -t layers < <(docker image inspect "$image_id" --format '{{range .RootFS.Layers}}{{println .}}{{end}}')
         echo "layer_count=${#layers[@]}"
         found="false"
         for digest in "${layers[@]:0:8}"; do
-          digest_path="${digest//:/\/}"
-          blob_path="$containerd_blobs_dir/$digest_path"
+          hex="${digest#sha256:}"
+          blob_path="$content_dir/blobs/sha256/$hex"
           echo "digest=$digest"
           echo "blob_path=$blob_path"
           echo "blob_path_real=$(sudo readlink -f "$blob_path" 2>/dev/null || echo "<missing>")"
@@ -97,13 +120,15 @@ jobs:
           fi
         done
         if [ "$found" != "true" ]; then
-          echo "ERROR: did not find any RootFS layer blobs on disk under $containerd_blobs_dir" >&2
+          echo "ERROR: did not find any RootFS layer blobs on disk under $content_dir/blobs/sha256" >&2
+          echo "Diagnostics: searching for blobs/sha256/ under docker_root_dir..."
+          sudo find "$docker_root_dir" -maxdepth 10 -type d -path '*/blobs/sha256' -print 2>/dev/null | head -n 200 || true
           exit 1
         fi
         echo "::endgroup::"
 
         echo "::group::Fallback: show some sha256 blobs under docker root"
-        sudo find "$docker_root_dir/containerd" -type f -path '*/io.containerd.content.v1.content/blobs/sha256/*' -printf '%p\n' 2>/dev/null | head -n 20 || true
+        sudo find "$docker_root_dir" -type f -path '*/io.containerd.content.v1.content/blobs/sha256/*' -printf '%p\n' 2>/dev/null | head -n 50 || true
         echo "::endgroup::"
 
         if [ "${{ inputs.explore_only }}" = "true" ]; then

--- a/.github/workflows/publish-challenges.yml
+++ b/.github/workflows/publish-challenges.yml
@@ -29,6 +29,7 @@ jobs:
     - uses: ./.github/actions/setup-challenge-runtime
 
     - name: Build challenge image(s)
+      id: build
       shell: 'nix develop -c bash -euo pipefail {0}'
       env:
         CHALLENGE_TARGET: ${{ inputs.challenge_target }}
@@ -39,14 +40,17 @@ jobs:
           printf '%s' "$GPG_PRIVATE_KEY" | gpg --batch --import
           git crypt unlock || true
         fi
-        ./pwnshop build "$CHALLENGE_TARGET"
+        image_id="$(./pwnshop build "$CHALLENGE_TARGET" | tail -n 1)"
+        echo "Built image: $image_id"
+        echo "image_id=$image_id" >>"$GITHUB_OUTPUT"
 
-    - name: Install rclone + skopeo
-      run: sudo apt-get update && sudo apt-get install -y rclone skopeo
+    - name: Install rclone
+      run: sudo apt-get update && sudo apt-get install -y rclone
 
-    - name: Explore local blob staging and remote location
+    - name: Explore blob locations on disk
       shell: 'nix develop -c bash -euo pipefail {0}'
       env:
+        IMAGE_ID: ${{ steps.build.outputs.image_id }}
         R2_BUCKET_NAME: challenges-registry
         RCLONE_CONFIG_R2_TYPE: s3
         RCLONE_CONFIG_R2_PROVIDER: Cloudflare
@@ -65,54 +69,35 @@ jobs:
         rclone lsf "r2:${R2_BUCKET_NAME}" --dirs-only --config /dev/null || true
         echo "::endgroup::"
 
-        publish_root="/mnt/pwn.college/publish-explore"
-        publish_blobs_dir="$publish_root/blobs"
-        publish_manifests_dir="$publish_root/manifests"
-        oci_root="$publish_root/oci"
-        sudo mkdir -p "$publish_root"
-        sudo chown -R "$(id -u):$(id -g)" "$publish_root"
-        mkdir -p "$publish_blobs_dir" "$publish_manifests_dir" "$oci_root"
+        image_id="${IMAGE_ID}"
+        if [ -z "$image_id" ]; then
+          echo "missing IMAGE_ID from build step" >&2
+          exit 1
+        fi
 
-        while IFS= read -r line; do
-          image_id="${line%% *}"
-          challenge_slug="${line#* }"
-          image_tag="pwncollege-challenge:${challenge_slug//\//-}"
-          docker tag "$image_id" "$image_tag"
+        sha="${image_id#sha256:}"
+        if [ "$sha" = "$image_id" ]; then
+          echo "unexpected image id format: $image_id" >&2
+          exit 1
+        fi
 
-          image_oci_dir="$oci_root/$challenge_slug"
-          mkdir -p "$image_oci_dir"
+        echo "::group::Locate $image_id under DockerRootDir"
+        echo "sha=$sha"
 
-          skopeo copy --insecure-policy "docker-daemon:$image_tag" "oci:$image_oci_dir:latest"
-          manifest_ref="$(jq -r '.manifests[0].digest' "$image_oci_dir/index.json")"
-          if [ -z "$manifest_ref" ] || [ "$manifest_ref" = "null" ]; then
-            echo "failed to resolve manifest digest for $challenge_slug (image_id=$image_id)" >&2
-            exit 1
-          fi
-
-          mkdir -p "$publish_manifests_dir/$challenge_slug"
-          printf '%s\n' "$manifest_ref" >"$publish_manifests_dir/$challenge_slug/latest"
-
-          cp -a -n "$image_oci_dir/blobs/." "$publish_blobs_dir/"
-        done < <(
-          docker image ls --filter "label=pwncollege.challenge" --no-trunc --quiet \
-            | xargs -r docker image inspect --format '{{.Id}} {{index .Config.Labels "pwncollege.challenge"}}'
+        # Common storage locations across Docker/BuildKit/containerd setups.
+        candidates=(
+          "$docker_root_dir/image/overlay2/imagedb/content/sha256/$sha"
+          "$docker_root_dir/buildkit/content/blobs/sha256/$sha"
+          "$docker_root_dir/containerd/daemon/io.containerd.content.v1.content/blobs/sha256/$sha"
         )
 
-        echo "::group::Local publish stats"
-        blob_file_count="$(find "$publish_blobs_dir" -type f | wc -l)"
-        echo "blob_file_count=$blob_file_count"
-        du -sh "$publish_blobs_dir" "$publish_manifests_dir" || true
-        first_blob_rel="$(find "$publish_blobs_dir" -type f -print -quit | sed "s#^$publish_blobs_dir/##" || true)"
-        echo "first_blob_rel=$first_blob_rel"
-        echo "::endgroup::"
+        for p in "${candidates[@]}"; do
+          echo "--- $p"
+          sudo ls -la "$p" 2>&1 || true
+        done
 
-        echo "::group::Remote existence checks (one sample blob)"
-        if [ -n "$first_blob_rel" ]; then
-          rclone lsjson "r2:${R2_BUCKET_NAME}/blobs/$first_blob_rel" --config /dev/null || true
-          rclone lsjson "r2:${R2_BUCKET_NAME}/$first_blob_rel" --config /dev/null || true
-          rclone lsjson "r2:${R2_BUCKET_NAME}/v2/blobs/$first_blob_rel" --config /dev/null || true
-          rclone lsjson "r2:${R2_BUCKET_NAME}/oci/blobs/$first_blob_rel" --config /dev/null || true
-        fi
+        echo "--- find $docker_root_dir -path '*/sha256/$sha'"
+        sudo find "$docker_root_dir" -type f -path "*/sha256/$sha" -print 2>/dev/null | head -n 50 || true
         echo "::endgroup::"
 
         if [ "${{ inputs.explore_only }}" = "true" ]; then
@@ -120,12 +105,8 @@ jobs:
           exit 0
         fi
 
-        echo "::group::rclone blobs (dry run)"
-        rclone copy "$publish_blobs_dir" "r2:${R2_BUCKET_NAME}/blobs" --dry-run --ignore-existing --config /dev/null --stats-one-line --stats-log-level NOTICE
-        echo "::endgroup::"
-
-        echo "::group::rclone manifests (dry run)"
-        rclone copy "$publish_manifests_dir" "r2:${R2_BUCKET_NAME}/manifests" --dry-run --config /dev/null --stats-one-line --stats-log-level NOTICE
+        echo "::group::Remote top-level prefixes (again)"
+        rclone lsf "r2:${R2_BUCKET_NAME}" --dirs-only --config /dev/null || true
         echo "::endgroup::"
 
   determine-modified-challenges:

--- a/.github/workflows/publish-challenges.yml
+++ b/.github/workflows/publish-challenges.yml
@@ -4,13 +4,131 @@ on:
   push:
     branches: [ main ]
   workflow_dispatch:
+    inputs:
+      challenge_group:
+        description: "Run publish/exploration for a single top-level challenge group (e.g. advent-of-pwn, web-security). Leave empty to use modified-challenges detection."
+        required: false
+        default: ""
+      explore_only:
+        description: "Run exploration only (no rclone copy)."
+        type: boolean
+        required: false
+        default: true
 
 concurrency:
   group: publish-challenges-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
+  explore:
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.challenge_group != '' }}
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: ./.github/actions/setup-nix
+    - uses: ./.github/actions/setup-challenge-runtime
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v7
+      with:
+        cache-dependency-glob: tools/dojo/**
+
+    - name: Build/test challenge images
+      uses: ./.github/actions/test-challenges
+      with:
+        challenges: ${{ inputs.challenge_group }}
+        modified_since_ref: ""
+        gpg_private_key: ${{ secrets.GPG_ROOT_PRIVATE_KEY }}
+
+    - name: Install rclone
+      run: sudo apt-get update && sudo apt-get install -y rclone
+
+    - name: Explore local blob staging and remote location
+      shell: 'nix develop -c bash -euo pipefail {0}'
+      env:
+        R2_BUCKET_NAME: challenges-registry
+        RCLONE_CONFIG_R2_TYPE: s3
+        RCLONE_CONFIG_R2_PROVIDER: Cloudflare
+        RCLONE_CONFIG_R2_ENDPOINT: https://${{ secrets.R2_ACCOUNT_ID }}.r2.cloudflarestorage.com
+        RCLONE_CONFIG_R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY }}
+        RCLONE_CONFIG_R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_KEY }}
+      run: |
+        docker_root_dir="$(docker info --format '{{.DockerRootDir}}')"
+        containerd_blobs_dir="$docker_root_dir/containerd/daemon/io.containerd.content.v1.content/blobs"
+
+        echo "::group::Docker/containerd paths"
+        echo "docker_root_dir=$docker_root_dir"
+        echo "containerd_blobs_dir=$containerd_blobs_dir"
+        echo "containerd_blobs_dir_dev=$(stat -c %d "$containerd_blobs_dir")"
+        df -T "$docker_root_dir" "$containerd_blobs_dir" || true
+        echo "::endgroup::"
+
+        echo "::group::Remote top-level prefixes"
+        rclone lsf "r2:${R2_BUCKET_NAME}" --dirs-only --config /dev/null || true
+        echo "::endgroup::"
+
+        publish_blobs_dir="$docker_root_dir/publish-explore/blobs"
+        publish_manifests_dir="$docker_root_dir/publish-explore/manifests"
+        sudo mkdir -p "$publish_blobs_dir" "$publish_manifests_dir"
+
+        while IFS= read -r line; do
+          image_id="${line%% *}"
+          challenge_slug="${line#* }"
+          stack=("$image_id")
+          while ((${#stack[@]})); do
+            digest="${stack[-1]}"
+            digest_path="${digest//:/\/}"
+            unset 'stack[-1]'
+            sudo mkdir -p "$publish_blobs_dir/${digest_path%%/*}"
+            if ! sudo ln "$containerd_blobs_dir/$digest_path" "$publish_blobs_dir/$digest_path" 2>ln.err; then
+              echo "hardlink failed for $digest_path: $(cat ln.err)" >&2
+              # Keep exploring even if hardlinks are unavailable.
+              sudo cp --reflink=auto "$containerd_blobs_dir/$digest_path" "$publish_blobs_dir/$digest_path" 2>/dev/null || true
+            fi
+            rm -f ln.err
+            mapfile -t -O "${#stack[@]}" stack < <(
+              sudo jq -r '.manifests[]?.digest,.config.digest?,.layers[]?.digest? | select(type=="string")' \
+                "$containerd_blobs_dir/$digest_path" 2>/dev/null
+            )
+          done
+          sudo mkdir -p "$publish_manifests_dir/$challenge_slug"
+          printf '%s\n' "$image_id" | sudo tee "$publish_manifests_dir/$challenge_slug/latest" >/dev/null
+        done < <(
+          docker image ls --filter "label=pwncollege.challenge" --no-trunc --quiet \
+            | xargs -r docker image inspect --format '{{.Id}} {{index .Config.Labels "pwncollege.challenge"}}'
+        )
+
+        echo "::group::Local publish stats"
+        echo "blob_file_count=$(sudo find \"$publish_blobs_dir\" -type f | wc -l)"
+        sudo du -sh "$publish_blobs_dir" "$publish_manifests_dir" || true
+        first_blob_rel="$(sudo find "$publish_blobs_dir" -type f -print -quit | sed "s#^$publish_blobs_dir/##" || true)"
+        echo "first_blob_rel=$first_blob_rel"
+        echo "::endgroup::"
+
+        echo "::group::Remote existence checks (one sample blob)"
+        if [ -n "$first_blob_rel" ]; then
+          rclone lsjson "r2:${R2_BUCKET_NAME}/blobs/$first_blob_rel" --config /dev/null || true
+          rclone lsjson "r2:${R2_BUCKET_NAME}/$first_blob_rel" --config /dev/null || true
+          rclone lsjson "r2:${R2_BUCKET_NAME}/v2/blobs/$first_blob_rel" --config /dev/null || true
+          rclone lsjson "r2:${R2_BUCKET_NAME}/oci/blobs/$first_blob_rel" --config /dev/null || true
+        fi
+        echo "::endgroup::"
+
+        if [ "${{ inputs.explore_only }}" = "true" ]; then
+          echo "explore_only=true: skipping rclone copy"
+          exit 0
+        fi
+
+        echo "::group::rclone blobs (dry run)"
+        rclone copy "$publish_blobs_dir" "r2:${R2_BUCKET_NAME}/blobs" --dry-run --ignore-existing --config /dev/null --stats-one-line --stats-log-level NOTICE
+        echo "::endgroup::"
+
+        echo "::group::rclone manifests (dry run)"
+        rclone copy "$publish_manifests_dir" "r2:${R2_BUCKET_NAME}/manifests" --dry-run --config /dev/null --stats-one-line --stats-log-level NOTICE
+        echo "::endgroup::"
+
   determine-modified-challenges:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.challenge_group == '' }}
     runs-on: ubuntu-latest
     outputs:
       challenges: ${{ steps.determine-modified-challenges.outputs.challenges }}

--- a/.github/workflows/publish-challenges.yml
+++ b/.github/workflows/publish-challenges.yml
@@ -56,11 +56,18 @@ jobs:
         echo "::group::Docker info"
         echo "docker_root_dir=$docker_root_dir"
         echo "docker_driver=$docker_driver"
+        echo "DOCKER_HOST=${DOCKER_HOST-}"
+        echo "docker_context=$(docker context show 2>/dev/null || true)"
+        docker context inspect --format '{{json .Endpoints.docker.Host}}' "$(docker context show 2>/dev/null || true)" 2>/dev/null || true
         docker info --format 'Driver={{.Driver}} RootDir={{.DockerRootDir}}'
         echo "--- top-level docker_root_dir"
         sudo ls -la "$docker_root_dir" || true
-        echo "--- docker_root_dir/image"
-        sudo ls -la "$docker_root_dir/image" || true
+        echo "--- likely blob-store dirs under docker_root_dir"
+        sudo find "$docker_root_dir" -maxdepth 6 -type d \( -path "*/blobs/sha256" -o -path "*/content/blobs/sha256" -o -name "io.containerd.content.v1.content" \) -print 2>/dev/null || true
+        if [ -d "$docker_root_dir/buildkit/content/blobs/sha256" ]; then
+          echo "--- docker_root_dir/buildkit/content/blobs/sha256 (sample)"
+          sudo ls -la "$docker_root_dir/buildkit/content/blobs/sha256" | head -n 30 || true
+        fi
         echo "::endgroup::"
 
         image_id="${IMAGE_ID}"
@@ -111,11 +118,15 @@ jobs:
         sudo find "$docker_root_dir/image" -maxdepth 10 -type f -path "*/imagedb/content/sha256/$sha_config" -print 2>/dev/null | head -n 50 || true
         echo "--- find $docker_root_dir -path '*/blobs/sha256/<digest>' (config)"
         sudo find "$docker_root_dir" -maxdepth 10 -type f -path "*/blobs/sha256/$sha_config" -print 2>/dev/null | head -n 50 || true
+        echo "--- find $docker_root_dir -path '*sha256/<digest>' (config, any depth-limited match)"
+        sudo find "$docker_root_dir" -maxdepth 10 -type f -path "*/sha256/$sha_config" -print 2>/dev/null | head -n 50 || true
         if [ -n "$sha_manifest" ]; then
           echo "--- find $docker_root_dir -path '*/imagedb/content/sha256/<digest>' (manifest)"
           sudo find "$docker_root_dir/image" -maxdepth 10 -type f -path "*/imagedb/content/sha256/$sha_manifest" -print 2>/dev/null | head -n 50 || true
           echo "--- find $docker_root_dir -path '*/blobs/sha256/<digest>' (manifest)"
           sudo find "$docker_root_dir" -maxdepth 10 -type f -path "*/blobs/sha256/$sha_manifest" -print 2>/dev/null | head -n 50 || true
+          echo "--- find $docker_root_dir -path '*sha256/<digest>' (manifest, any depth-limited match)"
+          sudo find "$docker_root_dir" -maxdepth 10 -type f -path "*/sha256/$sha_manifest" -print 2>/dev/null | head -n 50 || true
         fi
         echo "::endgroup::"
 

--- a/.github/workflows/publish-challenges.yml
+++ b/.github/workflows/publish-challenges.yml
@@ -70,65 +70,70 @@ jobs:
 
         docker_root_dir="$(docker info --format '{{.DockerRootDir}}')"
 
-        echo "::group::Locate containerd content store root"
+        echo "::group::Locate blob-like objects on disk (no publishing)"
         echo "docker_root_dir=$docker_root_dir"
         echo "docker_root_dir_real=$(readlink -f "$docker_root_dir" || echo "$docker_root_dir")"
+        echo "top_level_dirs:"
+        sudo ls -la "$docker_root_dir" | head -n 200 || true
+        echo "notable_dirs_under_docker_root:"
+        sudo find "$docker_root_dir" -maxdepth 6 -type d \( \
+          -name containerd -o -name blobs -o -name sha256 -o -name imagedb -o -name layerdb -o -name distribution -o -name io.containerd.content.v1.content \
+        \) -print 2>/dev/null | sort | head -n 200 || true
+
+        # Try to locate a containerd content store (if present) in a few likely roots.
         content_dir=""
-        for d in \
-          "$docker_root_dir/containerd/daemon/io.containerd.content.v1.content" \
-          "$docker_root_dir/containerd/io.containerd.content.v1.content"
-        do
-          if sudo test -d "$d"; then
+        for root in "$docker_root_dir" /mnt/pwn.college /var/lib/pwn.college /var/lib/containerd /var/lib/docker; do
+          [ -d "$root" ] || continue
+          d="$(sudo find "$root" -maxdepth 8 -type d -name io.containerd.content.v1.content -print -quit 2>/dev/null || true)"
+          if [ -n "$d" ]; then
             content_dir="$d"
             break
           fi
         done
-        if [ -z "$content_dir" ]; then
-          content_dir="$(sudo find "$docker_root_dir" -maxdepth 6 -type d -name io.containerd.content.v1.content -print -quit 2>/dev/null || true)"
-        fi
         echo "content_dir=${content_dir:-<not found>}"
         if [ -n "$content_dir" ]; then
           echo "content_dir_real=$(sudo readlink -f "$content_dir" 2>/dev/null || echo "$content_dir")"
-          content_blobs_dir="$content_dir/blobs"
-          echo "content_blobs_dir=$content_blobs_dir"
-          sudo ls -la "$content_blobs_dir" | head -n 80 || true
-          sudo ls -la "$content_blobs_dir/sha256" | head -n 80 || true
+          sudo ls -la "$content_dir" | head -n 200 || true
+          sudo ls -la "$content_dir/blobs/sha256" | head -n 50 || true
+        fi
+
+        # Independently, locate the Docker image config JSON by image_id in the classic image store layout.
+        config_hex="${image_id#sha256:}"
+        echo "image_config_digest_sha256=$config_hex"
+        config_path="$(sudo find "$docker_root_dir" -maxdepth 10 -type f -path "*/imagedb/content/sha256/$config_hex" -print -quit 2>/dev/null || true)"
+        echo "image_config_path=${config_path:-<not found>}"
+        if [ -n "$config_path" ]; then
+          sudo stat -c 'FOUND %n (%s bytes)' "$config_path"
+          sudo sed -n '1,30p' "$config_path" || true
         fi
         echo "::endgroup::"
 
         echo "::group::Verify at least one sha256 blob exists on disk for the built image"
-        if [ -z "${content_dir:-}" ]; then
-          echo "ERROR: could not locate io.containerd.content.v1.content under docker_root_dir=$docker_root_dir" >&2
-          sudo find "$docker_root_dir" -maxdepth 6 -type d -name containerd -o -name blobs -o -name io.containerd.content.v1.content 2>/dev/null | head -n 200 || true
-          exit 1
+        found="false"
+
+        if [ -n "${content_dir:-}" ]; then
+          sample_blob="$(sudo find "$content_dir/blobs/sha256" -maxdepth 1 -type f -print -quit 2>/dev/null || true)"
+          if [ -n "$sample_blob" ]; then
+            echo "FOUND containerd blob file: $sample_blob"
+            sudo stat -c 'FOUND %n (%s bytes)' "$sample_blob"
+            found="true"
+          fi
         fi
 
-        mapfile -t layers < <(docker image inspect "$image_id" --format '{{range .RootFS.Layers}}{{println .}}{{end}}')
-        echo "layer_count=${#layers[@]}"
-        found="false"
-        for digest in "${layers[@]:0:8}"; do
-          hex="${digest#sha256:}"
-          blob_path="$content_dir/blobs/sha256/$hex"
-          echo "digest=$digest"
-          echo "blob_path=$blob_path"
-          echo "blob_path_real=$(sudo readlink -f "$blob_path" 2>/dev/null || echo "<missing>")"
-          if sudo test -f "$blob_path"; then
-            sudo stat -c 'FOUND %n (%s bytes)' "$blob_path"
-            sudo ls -l "$blob_path"
-            found="true"
-            break
-          fi
-        done
+        if [ "$found" != "true" ] && [ -n "${config_path:-}" ]; then
+          echo "FOUND docker imagedb config JSON: $config_path"
+          found="true"
+        fi
+
         if [ "$found" != "true" ]; then
-          echo "ERROR: did not find any RootFS layer blobs on disk under $content_dir/blobs/sha256" >&2
-          echo "Diagnostics: searching for blobs/sha256/ under docker_root_dir..."
-          sudo find "$docker_root_dir" -maxdepth 10 -type d -path '*/blobs/sha256' -print 2>/dev/null | head -n 200 || true
+          echo "ERROR: could not find any digest-addressed objects (containerd blobs or docker imagedb config) on disk." >&2
           exit 1
         fi
         echo "::endgroup::"
 
         echo "::group::Fallback: show some sha256 blobs under docker root"
-        sudo find "$docker_root_dir" -type f -path '*/io.containerd.content.v1.content/blobs/sha256/*' -printf '%p\n' 2>/dev/null | head -n 50 || true
+        sudo find "$docker_root_dir" -type d -path '*/blobs/sha256' -print 2>/dev/null | head -n 50 || true
+        sudo find "$docker_root_dir" -type f -path '*/imagedb/content/sha256/*' -print 2>/dev/null | head -n 20 || true
         echo "::endgroup::"
 
         if [ "${{ inputs.explore_only }}" = "true" ]; then

--- a/.github/workflows/publish-challenges.yml
+++ b/.github/workflows/publish-challenges.yml
@@ -62,9 +62,11 @@ jobs:
         RCLONE_CONFIG_R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY }}
         RCLONE_CONFIG_R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_KEY }}
       run: |
-        containerd_blobs_dir="$(docker info --format '{{.DockerRootDir}}')/containerd/daemon/io.containerd.content.v1.content/blobs"
-        publish_blobs_dir="/mnt/publish/blobs"
-        publish_manifests_dir="/mnt/publish/manifests"
+        docker_root_dir="$(docker info --format '{{.DockerRootDir}}')"
+        containerd_blobs_dir="$docker_root_dir/containerd/daemon/io.containerd.content.v1.content/blobs"
+        # Keep the publish staging area on the same filesystem as the containerd content store so we can hardlink blobs.
+        publish_blobs_dir="$docker_root_dir/publish/blobs"
+        publish_manifests_dir="$docker_root_dir/publish/manifests"
         sudo mkdir -p "$publish_blobs_dir" "$publish_manifests_dir"
         while IFS= read -r line; do
           image_id="${line%% *}"

--- a/.github/workflows/publish-challenges.yml
+++ b/.github/workflows/publish-challenges.yml
@@ -25,108 +25,58 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+    - uses: ./.github/actions/setup-nix
+    - uses: ./.github/actions/setup-challenge-runtime
 
-    - name: Pull image
-      id: pull
-      shell: bash -euo pipefail {0}
+    - name: Explore pwn-challenge-runtime blob store
+      shell: 'nix develop -c bash -euo pipefail {0}'
       env:
         IMAGE_REF: ${{ inputs.image_ref }}
       run: |
+        echo "::group::Runtime env"
+        echo "DOCKER_HOST=$DOCKER_HOST"
+        docker info --format 'Driver={{.Driver}} RootDir={{.DockerRootDir}}'
+        echo "::endgroup::"
+
         docker pull "$IMAGE_REF"
         image_id="$(docker image inspect --format '{{.Id}}' "$IMAGE_REF")"
         repo_digest="$(docker image inspect --format '{{index .RepoDigests 0}}' "$IMAGE_REF" 2>/dev/null || true)"
-        echo "Pulled image: $IMAGE_REF"
-        echo "image_id=$image_id"
-        echo "repo_digest=$repo_digest"
-        echo "image_id=$image_id" >>"$GITHUB_OUTPUT"
 
-    - name: Explore blob locations on disk
-      shell: bash -euo pipefail {0}
-      env:
-        IMAGE_ID: ${{ steps.pull.outputs.image_id }}
-        IMAGE_REF: ${{ inputs.image_ref }}
-      run: |
         docker_root_dir="$(docker info --format '{{.DockerRootDir}}')"
-        docker_driver="$(docker info --format '{{.Driver}}')"
         echo "::group::Inputs"
         echo "image_ref=$IMAGE_REF"
-        echo "image_id=$IMAGE_ID"
-        echo "::endgroup::"
-
-        echo "::group::Docker info"
+        echo "image_id=$image_id"
+        echo "repo_digest=$repo_digest"
         echo "docker_root_dir=$docker_root_dir"
-        echo "docker_driver=$docker_driver"
-        echo "DOCKER_HOST=${DOCKER_HOST-}"
-        echo "docker_context=$(docker context show 2>/dev/null || true)"
-        docker context inspect --format '{{json .Endpoints.docker.Host}}' "$(docker context show 2>/dev/null || true)" 2>/dev/null || true
-        docker info --format 'Driver={{.Driver}} RootDir={{.DockerRootDir}}'
-        echo "--- top-level docker_root_dir"
-        sudo ls -la "$docker_root_dir" || true
-        echo "--- likely blob-store dirs under docker_root_dir"
-        sudo find "$docker_root_dir" -maxdepth 6 -type d \( -path "*/blobs/sha256" -o -path "*/content/blobs/sha256" -o -name "io.containerd.content.v1.content" \) -print 2>/dev/null || true
-        if [ -d "$docker_root_dir/buildkit/content/blobs/sha256" ]; then
-          echo "--- docker_root_dir/buildkit/content/blobs/sha256 (sample)"
-          sudo ls -la "$docker_root_dir/buildkit/content/blobs/sha256" | head -n 30 || true
-        fi
         echo "::endgroup::"
-
-        image_id="${IMAGE_ID}"
-        if [ -z "$image_id" ]; then
-          echo "missing IMAGE_ID from build step" >&2
-          exit 1
-        fi
 
         sha_config="${image_id#sha256:}"
-        if [ "$sha_config" = "$image_id" ]; then
-          echo "unexpected image id format: $image_id" >&2
-          exit 1
-        fi
-
-        # RepoDigests exist for pulled images; the digest portion may also exist in the on-disk blob stores.
-        repo_digest="$(docker image inspect --format '{{index .RepoDigests 0}}' "$IMAGE_REF" 2>/dev/null || true)"
         sha_manifest=""
         if [[ "$repo_digest" == *@sha256:* ]]; then
           sha_manifest="${repo_digest##*@sha256:}"
         fi
 
-        echo "::group::Locate sha256 objects under DockerRootDir"
+        containerd_blobs_dir="$docker_root_dir/containerd/daemon/io.containerd.content.v1.content/blobs"
+        echo "::group::Containerd blobs store"
+        echo "containerd_blobs_dir=$containerd_blobs_dir"
+        sudo ls -la "$containerd_blobs_dir" || true
+        sudo ls -la "$containerd_blobs_dir/sha256" 2>/dev/null | head -n 40 || true
+        echo "::endgroup::"
+
+        echo "::group::Locate digests on disk"
         echo "sha_config=$sha_config"
-        echo "repo_digest=$repo_digest"
         echo "sha_manifest=$sha_manifest"
-
-        # Common storage locations across Docker/BuildKit/containerd setups.
-        candidates=(
-          "$docker_root_dir/image/$docker_driver/imagedb/content/sha256/$sha_config"
-          "$docker_root_dir/image/overlay2/imagedb/content/sha256/$sha_config"
-          "$docker_root_dir/image/overlayfs/imagedb/content/sha256/$sha_config"
-          "$docker_root_dir/buildkit/content/blobs/sha256/$sha_config"
-          "$docker_root_dir/containerd/daemon/io.containerd.content.v1.content/blobs/sha256/$sha_config"
-        )
+        echo "--- config"
+        sudo ls -la "$containerd_blobs_dir/sha256/$sha_config" 2>&1 || true
+        echo "--- manifest"
         if [ -n "$sha_manifest" ]; then
-          candidates+=(
-            "$docker_root_dir/buildkit/content/blobs/sha256/$sha_manifest"
-            "$docker_root_dir/containerd/daemon/io.containerd.content.v1.content/blobs/sha256/$sha_manifest"
-          )
+          sudo ls -la "$containerd_blobs_dir/sha256/$sha_manifest" 2>&1 || true
         fi
-
-        for p in "${candidates[@]}"; do
-          echo "--- $p"
-          sudo ls -la "$p" 2>&1 || true
-        done
-
-        echo "--- find $docker_root_dir -path '*/imagedb/content/sha256/<digest>' (config)"
-        sudo find "$docker_root_dir/image" -maxdepth 10 -type f -path "*/imagedb/content/sha256/$sha_config" -print 2>/dev/null | head -n 50 || true
-        echo "--- find $docker_root_dir -path '*/blobs/sha256/<digest>' (config)"
+        echo "--- find (config)"
         sudo find "$docker_root_dir" -maxdepth 10 -type f -path "*/blobs/sha256/$sha_config" -print 2>/dev/null | head -n 50 || true
-        echo "--- find $docker_root_dir -path '*sha256/<digest>' (config, any depth-limited match)"
-        sudo find "$docker_root_dir" -maxdepth 10 -type f -path "*/sha256/$sha_config" -print 2>/dev/null | head -n 50 || true
         if [ -n "$sha_manifest" ]; then
-          echo "--- find $docker_root_dir -path '*/imagedb/content/sha256/<digest>' (manifest)"
-          sudo find "$docker_root_dir/image" -maxdepth 10 -type f -path "*/imagedb/content/sha256/$sha_manifest" -print 2>/dev/null | head -n 50 || true
-          echo "--- find $docker_root_dir -path '*/blobs/sha256/<digest>' (manifest)"
+          echo "--- find (manifest)"
           sudo find "$docker_root_dir" -maxdepth 10 -type f -path "*/blobs/sha256/$sha_manifest" -print 2>/dev/null | head -n 50 || true
-          echo "--- find $docker_root_dir -path '*sha256/<digest>' (manifest, any depth-limited match)"
-          sudo find "$docker_root_dir" -maxdepth 10 -type f -path "*/sha256/$sha_manifest" -print 2>/dev/null | head -n 50 || true
         fi
         echo "::endgroup::"
 

--- a/.github/workflows/publish-challenges.yml
+++ b/.github/workflows/publish-challenges.yml
@@ -5,10 +5,10 @@ on:
     branches: [ main ]
   workflow_dispatch:
     inputs:
-      challenge_group:
-        description: "Run publish/exploration for a single top-level challenge group (e.g. advent-of-pwn, web-security). Leave empty to use modified-challenges detection."
-        required: false
-        default: ""
+      challenge_target:
+        description: "Path to a single challenge (or a folder of challenges) to build for exploration, e.g. challenges/advent-of-pwn/2025/day-01."
+        required: true
+        default: challenges/advent-of-pwn/2025/day-01
       explore_only:
         description: "Run exploration only (no rclone copy)."
         type: boolean
@@ -21,24 +21,25 @@ concurrency:
 
 jobs:
   explore:
-    if: ${{ github.event_name == 'workflow_dispatch' && inputs.challenge_group != '' }}
+    if: ${{ github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
     - uses: ./.github/actions/setup-nix
     - uses: ./.github/actions/setup-challenge-runtime
 
-    - name: Install uv
-      uses: astral-sh/setup-uv@v7
-      with:
-        cache-dependency-glob: tools/dojo/**
-
-    - name: Build/test challenge images
-      uses: ./.github/actions/test-challenges
-      with:
-        challenges: ${{ inputs.challenge_group }}
-        modified_since_ref: ""
-        gpg_private_key: ${{ secrets.GPG_ROOT_PRIVATE_KEY }}
+    - name: Build challenge image(s)
+      shell: 'nix develop -c bash -euo pipefail {0}'
+      env:
+        CHALLENGE_TARGET: ${{ inputs.challenge_target }}
+        GPG_PRIVATE_KEY: ${{ secrets.GPG_ROOT_PRIVATE_KEY }}
+      run: |
+        # Some targets include git-crypt'd tests; import key so builds that need them can proceed.
+        if [ -n "${GPG_PRIVATE_KEY:-}" ]; then
+          printf '%s' "$GPG_PRIVATE_KEY" | gpg --batch --import
+          git crypt unlock || true
+        fi
+        ./pwnshop build "$CHALLENGE_TARGET"
 
     - name: Install rclone
       run: sudo apt-get update && sudo apt-get install -y rclone
@@ -128,7 +129,7 @@ jobs:
         echo "::endgroup::"
 
   determine-modified-challenges:
-    if: ${{ github.event_name != 'workflow_dispatch' || inputs.challenge_group == '' }}
+    if: ${{ github.event_name != 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     outputs:
       challenges: ${{ steps.determine-modified-challenges.outputs.challenges }}

--- a/.github/workflows/publish-challenges.yml
+++ b/.github/workflows/publish-challenges.yml
@@ -47,6 +47,7 @@ jobs:
         IMAGE_REF: ${{ inputs.image_ref }}
       run: |
         docker_root_dir="$(docker info --format '{{.DockerRootDir}}')"
+        docker_driver="$(docker info --format '{{.Driver}}')"
         echo "::group::Inputs"
         echo "image_ref=$IMAGE_REF"
         echo "image_id=$IMAGE_ID"
@@ -54,7 +55,12 @@ jobs:
 
         echo "::group::Docker info"
         echo "docker_root_dir=$docker_root_dir"
+        echo "docker_driver=$docker_driver"
         docker info --format 'Driver={{.Driver}} RootDir={{.DockerRootDir}}'
+        echo "--- top-level docker_root_dir"
+        sudo ls -la "$docker_root_dir" || true
+        echo "--- docker_root_dir/image"
+        sudo ls -la "$docker_root_dir/image" || true
         echo "::endgroup::"
 
         image_id="${IMAGE_ID}"
@@ -83,7 +89,9 @@ jobs:
 
         # Common storage locations across Docker/BuildKit/containerd setups.
         candidates=(
+          "$docker_root_dir/image/$docker_driver/imagedb/content/sha256/$sha_config"
           "$docker_root_dir/image/overlay2/imagedb/content/sha256/$sha_config"
+          "$docker_root_dir/image/overlayfs/imagedb/content/sha256/$sha_config"
           "$docker_root_dir/buildkit/content/blobs/sha256/$sha_config"
           "$docker_root_dir/containerd/daemon/io.containerd.content.v1.content/blobs/sha256/$sha_config"
         )
@@ -99,11 +107,15 @@ jobs:
           sudo ls -la "$p" 2>&1 || true
         done
 
-        echo "--- find $docker_root_dir -path '*/sha256/<digest>' (config)"
-        sudo find "$docker_root_dir" -maxdepth 10 -type f -path "*/sha256/$sha_config" -print 2>/dev/null | head -n 50 || true
+        echo "--- find $docker_root_dir -path '*/imagedb/content/sha256/<digest>' (config)"
+        sudo find "$docker_root_dir/image" -maxdepth 10 -type f -path "*/imagedb/content/sha256/$sha_config" -print 2>/dev/null | head -n 50 || true
+        echo "--- find $docker_root_dir -path '*/blobs/sha256/<digest>' (config)"
+        sudo find "$docker_root_dir" -maxdepth 10 -type f -path "*/blobs/sha256/$sha_config" -print 2>/dev/null | head -n 50 || true
         if [ -n "$sha_manifest" ]; then
-          echo "--- find $docker_root_dir -path '*/sha256/<digest>' (manifest)"
-          sudo find "$docker_root_dir" -maxdepth 10 -type f -path "*/sha256/$sha_manifest" -print 2>/dev/null | head -n 50 || true
+          echo "--- find $docker_root_dir -path '*/imagedb/content/sha256/<digest>' (manifest)"
+          sudo find "$docker_root_dir/image" -maxdepth 10 -type f -path "*/imagedb/content/sha256/$sha_manifest" -print 2>/dev/null | head -n 50 || true
+          echo "--- find $docker_root_dir -path '*/blobs/sha256/<digest>' (manifest)"
+          sudo find "$docker_root_dir" -maxdepth 10 -type f -path "*/blobs/sha256/$sha_manifest" -print 2>/dev/null | head -n 50 || true
         fi
         echo "::endgroup::"
 

--- a/.github/workflows/publish-challenges.yml
+++ b/.github/workflows/publish-challenges.yml
@@ -44,29 +44,16 @@ jobs:
         echo "Built image: $image_id"
         echo "image_id=$image_id" >>"$GITHUB_OUTPUT"
 
-    - name: Install rclone
-      run: sudo apt-get update && sudo apt-get install -y rclone
-
     - name: Explore blob locations on disk
       shell: 'nix develop -c bash -euo pipefail {0}'
       env:
         IMAGE_ID: ${{ steps.build.outputs.image_id }}
-        R2_BUCKET_NAME: challenges-registry
-        RCLONE_CONFIG_R2_TYPE: s3
-        RCLONE_CONFIG_R2_PROVIDER: Cloudflare
-        RCLONE_CONFIG_R2_ENDPOINT: https://${{ secrets.R2_ACCOUNT_ID }}.r2.cloudflarestorage.com
-        RCLONE_CONFIG_R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY }}
-        RCLONE_CONFIG_R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_KEY }}
       run: |
         docker_root_dir="$(docker info --format '{{.DockerRootDir}}')"
 
         echo "::group::Docker info"
         echo "docker_root_dir=$docker_root_dir"
         docker info --format 'Driver={{.Driver}} RootDir={{.DockerRootDir}}'
-        echo "::endgroup::"
-
-        echo "::group::Remote top-level prefixes"
-        rclone lsf "r2:${R2_BUCKET_NAME}" --dirs-only --config /dev/null || true
         echo "::endgroup::"
 
         image_id="${IMAGE_ID}"
@@ -97,17 +84,13 @@ jobs:
         done
 
         echo "--- find $docker_root_dir -path '*/sha256/$sha'"
-        sudo find "$docker_root_dir" -type f -path "*/sha256/$sha" -print 2>/dev/null | head -n 50 || true
+        sudo find "$docker_root_dir" -maxdepth 8 -type f -path "*/sha256/$sha" -print 2>/dev/null | head -n 50 || true
         echo "::endgroup::"
 
         if [ "${{ inputs.explore_only }}" = "true" ]; then
-          echo "explore_only=true: skipping rclone copy"
+          echo "explore_only=true"
           exit 0
         fi
-
-        echo "::group::Remote top-level prefixes (again)"
-        rclone lsf "r2:${R2_BUCKET_NAME}" --dirs-only --config /dev/null || true
-        echo "::endgroup::"
 
   determine-modified-challenges:
     if: ${{ github.event_name != 'workflow_dispatch' }}

--- a/.github/workflows/publish-challenges.yml
+++ b/.github/workflows/publish-challenges.yml
@@ -5,10 +5,10 @@ on:
     branches: [ main ]
   workflow_dispatch:
     inputs:
-      image_ref:
-        description: "Image to pull for on-runner blob location exploration (e.g. busybox:latest, alpine:latest)."
+      challenge:
+        description: "Challenge to build for on-runner blob location exploration (group/slug, e.g. sql-playground/sql-where)."
         required: true
-        default: busybox:latest
+        default: sql-playground/sql-where
       explore_only:
         description: "Run exploration only (no rclone copy)."
         type: boolean
@@ -25,59 +25,85 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: ./.github/actions/setup-nix
-    - uses: ./.github/actions/setup-challenge-runtime
+    - name: Install Nix (no cache action)
+      uses: DeterminateSystems/determinate-nix-action@v3.14.0
+      with:
+        extra-conf: |
+          accept-flake-config = true
 
-    - name: Explore pwn-challenge-runtime blob store
-      shell: 'nix develop -c bash -euo pipefail {0}'
-      env:
-        IMAGE_REF: ${{ inputs.image_ref }}
+    - name: Setup challenge runtime mountpoint
+      shell: bash -euo pipefail {0}
       run: |
-        echo "::group::Runtime env"
-        echo "DOCKER_HOST=$DOCKER_HOST"
+        sudo mkdir -p /mnt/pwn.college
+        sudo ln -sfn /mnt/pwn.college /var/lib/pwn.college
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v7
+      with:
+        cache-dependency-glob: tools/dojo/**
+
+    - name: Build 1 challenge and print containerd sha256 blob paths
+      shell: 'nix develop -c bash -euo pipefail {0}'
+      run: |
+        echo "::group::Runtime + docker daemon"
+        echo "DOCKER_HOST=${DOCKER_HOST:-<unset>}"
+        for i in $(seq 1 60); do
+          docker info >/dev/null 2>&1 && break
+          sleep 1
+        done
         docker info --format 'Driver={{.Driver}} RootDir={{.DockerRootDir}}'
         echo "::endgroup::"
 
-        docker pull "$IMAGE_REF"
-        image_id="$(docker image inspect --format '{{.Id}}' "$IMAGE_REF")"
-        repo_digest="$(docker image inspect --format '{{index .RepoDigests 0}}' "$IMAGE_REF" 2>/dev/null || true)"
+        echo "::group::Manage encrypted files (no key in this workflow)"
+        git crypt status -e \
+          | sed -n 's/^[[:space:]]*encrypted:[[:space:]]*//p' \
+          | sort -u \
+          | xargs -r rm -f
+        echo "::endgroup::"
+
+        echo "::group::Build one challenge"
+        challenge_dir="challenges/${{ inputs.challenge }}"
+        echo "challenge_dir=$challenge_dir"
+        image_id="$(./pwnshop build "$challenge_dir" | tail -n 1)"
+        echo "image_id=$image_id"
+        echo "::endgroup::"
 
         docker_root_dir="$(docker info --format '{{.DockerRootDir}}')"
-        echo "::group::Inputs"
-        echo "image_ref=$IMAGE_REF"
-        echo "image_id=$image_id"
-        echo "repo_digest=$repo_digest"
-        echo "docker_root_dir=$docker_root_dir"
-        echo "::endgroup::"
-
-        sha_config="${image_id#sha256:}"
-        sha_manifest=""
-        if [[ "$repo_digest" == *@sha256:* ]]; then
-          sha_manifest="${repo_digest##*@sha256:}"
-        fi
-
         containerd_blobs_dir="$docker_root_dir/containerd/daemon/io.containerd.content.v1.content/blobs"
-        echo "::group::Containerd blobs store"
+
+        echo "::group::Containerd content store (expected location)"
+        echo "docker_root_dir=$docker_root_dir"
+        echo "docker_root_dir_real=$(readlink -f "$docker_root_dir" || echo "$docker_root_dir")"
         echo "containerd_blobs_dir=$containerd_blobs_dir"
-        sudo ls -la "$containerd_blobs_dir" || true
-        sudo ls -la "$containerd_blobs_dir/sha256" 2>/dev/null | head -n 40 || true
+        echo "containerd_blobs_dir_real=$(readlink -f "$containerd_blobs_dir" || echo "$containerd_blobs_dir")"
+        sudo ls -la "$containerd_blobs_dir/sha256" | head -n 40 || true
         echo "::endgroup::"
 
-        echo "::group::Locate digests on disk"
-        echo "sha_config=$sha_config"
-        echo "sha_manifest=$sha_manifest"
-        echo "--- config"
-        sudo ls -la "$containerd_blobs_dir/sha256/$sha_config" 2>&1 || true
-        echo "--- manifest"
-        if [ -n "$sha_manifest" ]; then
-          sudo ls -la "$containerd_blobs_dir/sha256/$sha_manifest" 2>&1 || true
+        echo "::group::Verify at least one sha256 blob exists on disk for the built image"
+        mapfile -t layers < <(docker image inspect "$image_id" --format '{{range .RootFS.Layers}}{{println .}}{{end}}')
+        echo "layer_count=${#layers[@]}"
+        found="false"
+        for digest in "${layers[@]:0:8}"; do
+          digest_path="${digest//:/\/}"
+          blob_path="$containerd_blobs_dir/$digest_path"
+          echo "digest=$digest"
+          echo "blob_path=$blob_path"
+          echo "blob_path_real=$(sudo readlink -f "$blob_path" 2>/dev/null || echo "<missing>")"
+          if sudo test -f "$blob_path"; then
+            sudo stat -c 'FOUND %n (%s bytes)' "$blob_path"
+            sudo ls -l "$blob_path"
+            found="true"
+            break
+          fi
+        done
+        if [ "$found" != "true" ]; then
+          echo "ERROR: did not find any RootFS layer blobs on disk under $containerd_blobs_dir" >&2
+          exit 1
         fi
-        echo "--- find (config)"
-        sudo find "$docker_root_dir" -maxdepth 10 -type f -path "*/blobs/sha256/$sha_config" -print 2>/dev/null | head -n 50 || true
-        if [ -n "$sha_manifest" ]; then
-          echo "--- find (manifest)"
-          sudo find "$docker_root_dir" -maxdepth 10 -type f -path "*/blobs/sha256/$sha_manifest" -print 2>/dev/null | head -n 50 || true
-        fi
+        echo "::endgroup::"
+
+        echo "::group::Fallback: show some sha256 blobs under docker root"
+        sudo find "$docker_root_dir/containerd" -type f -path '*/io.containerd.content.v1.content/blobs/sha256/*' -printf '%p\n' 2>/dev/null | head -n 20 || true
         echo "::endgroup::"
 
         if [ "${{ inputs.explore_only }}" = "true" ]; then


### PR DESCRIPTION
Fix blob staging path in publish workflow to keep it on the same filesystem as Docker's containerd content store (hardlinking blobs from /var/lib/docker -> /mnt was silently failing).\n\nAdds a manual "Explore Publish Blobs" workflow to inspect local staging + the R2 bucket prefixes and sanity-check a sample blob object location.