### PR TITLE
ci: fix publish blob location

### DIFF
--- a/.github/workflows/publish-challenges.yml
+++ b/.github/workflows/publish-challenges.yml
@@ -62,8 +62,8 @@ jobs:
         RCLONE_CONFIG_R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY }}
         RCLONE_CONFIG_R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_KEY }}
       run: |
-        containerd_blobs_dir="$(docker info --format '{{.DockerRootDir}}')/containerd/daemon/io.containerd.content.v1.content/blobs"
-        publish_blobs_dir="$(docker info --format '{{.DockerRootDir}}')/publish/blobs"
+        containerd_blobs_dir="/var/lib/containerd/io.containerd.content.v1.content/blobs"
+        publish_blobs_dir="/mnt/publish/blobs"
         publish_manifests_dir="/mnt/publish/manifests"
         sudo mkdir -p "$publish_blobs_dir" "$publish_manifests_dir"
         while IFS= read -r line; do

--- a/.github/workflows/publish-challenges.yml
+++ b/.github/workflows/publish-challenges.yml
@@ -63,7 +63,7 @@ jobs:
         RCLONE_CONFIG_R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_KEY }}
       run: |
         containerd_blobs_dir="$(docker info --format '{{.DockerRootDir}}')/containerd/daemon/io.containerd.content.v1.content/blobs"
-        publish_blobs_dir="/mnt/publish/blobs"
+        publish_blobs_dir="$(docker info --format '{{.DockerRootDir}}')/publish/blobs"
         publish_manifests_dir="/mnt/publish/manifests"
         sudo mkdir -p "$publish_blobs_dir" "$publish_manifests_dir"
         while IFS= read -r line; do


### PR DESCRIPTION
Fixes empty blob publish staging: hardlinks into /mnt/publish fail cross-filesystem, leaving "rclone blobs" at 0 B.\n\nStage blobs under the same DockerRootDir as containerd so hardlinks succeed.