### PR TITLE
runtime: run dedicated containerd

### DIFF
--- a/runtime/default.nix
+++ b/runtime/default.nix
@@ -141,10 +141,9 @@ pkgs.writeShellApplication {
   text = ''
     set -euo pipefail
 
-    unit_base="${name}"
-    docker_socket_unit="$unit_base-docker.socket"
-    docker_service_unit="$unit_base-docker.service"
-    containerd_service_unit="$unit_base-containerd.service"
+    docker_socket_unit="${name}-docker.socket"
+    docker_service_unit="${name}-docker.service"
+    containerd_service_unit="${name}-containerd.service"
     host="unix://${dockerSockPath}"
 
     current_execstart="$(systemctl show -p ExecStart "$docker_service_unit" 2>/dev/null || true)"
@@ -164,7 +163,7 @@ pkgs.writeShellApplication {
     ln -sfn "${containerdServiceUnit}" "/run/systemd/system/$containerd_service_unit"
 
     mkdir -p /nix/var/nix/gcroots
-    ln -sfn "${dockerSystemdServiceUnit}" "/nix/var/nix/gcroots/$unit_base"
+    ln -sfn "${dockerSystemdServiceUnit}" "/nix/var/nix/gcroots/${name}"
 
     systemctl daemon-reload
     systemctl enable --runtime --now "$containerd_service_unit" >/dev/null

--- a/runtime/default.nix
+++ b/runtime/default.nix
@@ -2,12 +2,15 @@
 let
   name = "pwn-challenge-runtime";
 
-  dataRoot = "/var/lib/pwn.college/docker";
-  runRoot = "/run/pwn.college/docker";
+  dataBase = "/var/lib/pwn.college";
+  runBase = "/run/pwn.college";
+
+  dataRoot = "${dataBase}/docker";
+  runRoot = "${runBase}/docker";
   sockPath = "${runRoot}/docker.sock";
 
-  containerdDataRoot = "/var/lib/pwn.college/containerd";
-  containerdRunRoot = "/run/pwn.college/containerd";
+  containerdDataRoot = "${dataBase}/containerd";
+  containerdRunRoot = "${runBase}/containerd";
   containerdSockPath = "${containerdRunRoot}/containerd.sock";
   containerdSockAddr = "unix://${containerdSockPath}";
 

--- a/runtime/default.nix
+++ b/runtime/default.nix
@@ -59,7 +59,7 @@ let
     "pidfile" = "${dockerRunDir}/dockerd.pid";
     "log-driver" = "journald";
     "seccomp-profile" = "${seccompProfile}";
-    "containerd" = "unix://${containerdSockPath}";
+    "containerd" = "${containerdSockPath}";
 
     "features" = {
       "containerd-snapshotter" = true;
@@ -148,8 +148,6 @@ pkgs.writeShellApplication {
     docker_socket_unit="${name}-docker.socket"
     docker_service_unit="${name}-docker.service"
     containerd_service_unit="${name}-containerd.service"
-    legacy_docker_socket_unit="${name}.socket"
-    legacy_docker_service_unit="${name}.service"
 
     current_service_link="$(readlink -f "/run/systemd/system/$docker_service_unit" 2>/dev/null || true)"
 
@@ -169,11 +167,6 @@ pkgs.writeShellApplication {
 
     mkdir -p /nix/var/nix/gcroots
     ln -sfn "${dockerSystemdServiceUnit}" "/nix/var/nix/gcroots/${name}"
-
-    # Best-effort migration from pre -docker.{socket,service} unit names.
-    systemctl stop "$legacy_docker_service_unit" >/dev/null 2>&1 || true
-    systemctl stop "$legacy_docker_socket_unit" >/dev/null 2>&1 || true
-    systemctl disable --runtime "$legacy_docker_socket_unit" >/dev/null 2>&1 || true
 
     systemctl daemon-reload
     systemctl enable --runtime "$containerd_service_unit" >/dev/null 2>&1 || true

--- a/runtime/default.nix
+++ b/runtime/default.nix
@@ -25,8 +25,7 @@ let
   systemdServiceCommon = {
     Service = {
       Type = "notify";
-      Environment =
-        "PATH=${pkgs.kata-runtime}/bin:${pkgs.docker}/bin:${pkgs.containerd}/bin:/usr/sbin:/usr/bin:/sbin:/bin";
+      Environment = "PATH=${pkgs.kata-runtime}/bin:${pkgs.docker}/bin:${pkgs.containerd}/bin:/usr/sbin:/usr/bin:/sbin:/bin";
       Restart = "on-failure";
       TimeoutStartSec = 0;
       Delegate = "yes";
@@ -89,16 +88,24 @@ let
     };
   };
 
-  dockerSystemdServiceUnit = toSystemdUnit "${name}-docker.service" (lib.recursiveUpdate systemdServiceCommon {
-    Unit = {
-      Description = "pwn.college challenge runtime docker daemon";
-      Requires = [ "${name}-docker.socket" "${name}-containerd.service" ];
-      After = [ "local-fs.target" "${name}-containerd.service" ];
-    };
-    Service = {
-      ExecStart = "${pkgs.docker}/bin/dockerd --config-file=${dockerDaemonJson} -H fd://";
-    };
-  });
+  dockerSystemdServiceUnit = toSystemdUnit "${name}-docker.service" (
+    lib.recursiveUpdate systemdServiceCommon {
+      Unit = {
+        Description = "pwn.college challenge runtime docker daemon";
+        Requires = [
+          "${name}-docker.socket"
+          "${name}-containerd.service"
+        ];
+        After = [
+          "local-fs.target"
+          "${name}-containerd.service"
+        ];
+      };
+      Service = {
+        ExecStart = "${pkgs.docker}/bin/dockerd --config-file=${dockerDaemonJson} -H fd://";
+      };
+    }
+  );
 
   containerdConfigToml = pkgs.writeText "${name}-containerd-config.toml" ''
     version = 2
@@ -109,17 +116,19 @@ let
       address = "${containerdSockPath}"
   '';
 
-  containerdServiceUnit = toSystemdUnit "${name}-containerd.service" (lib.recursiveUpdate systemdServiceCommon {
-    Unit = {
-      Description = "pwn.college challenge runtime containerd";
-      After = "local-fs.target";
-    };
-    Service = {
-      ExecStart = "${pkgs.containerd}/bin/containerd --config ${containerdConfigToml}";
-      NotifyAccess = "all";
-      TimeoutStartSec = 60;
-    };
-  });
+  containerdServiceUnit = toSystemdUnit "${name}-containerd.service" (
+    lib.recursiveUpdate systemdServiceCommon {
+      Unit = {
+        Description = "pwn.college challenge runtime containerd";
+        After = "local-fs.target";
+      };
+      Service = {
+        ExecStart = "${pkgs.containerd}/bin/containerd --config ${containerdConfigToml}";
+        NotifyAccess = "all";
+        TimeoutStartSec = 60;
+      };
+    }
+  );
 
 in
 pkgs.writeShellApplication {

--- a/runtime/default.nix
+++ b/runtime/default.nix
@@ -143,12 +143,12 @@ pkgs.writeShellApplication {
     set -euo pipefail
 
     unit_base="${name}"
-    socket_unit="$unit_base-docker.socket"
-    service_unit="$unit_base-docker.service"
-    containerd_unit="$unit_base-containerd.service"
+    docker_socket_unit="$unit_base-docker.socket"
+    docker_service_unit="$unit_base-docker.service"
+    containerd_service_unit="$unit_base-containerd.service"
     host="unix://${dockerSockPath}"
 
-    current_execstart="$(systemctl show -p ExecStart "$service_unit" 2>/dev/null || true)"
+    current_execstart="$(systemctl show -p ExecStart "$docker_service_unit" 2>/dev/null || true)"
     want_cfg="--config-file=${dockerDaemonJson}"
 
     if [[ "$current_execstart" == *"$want_cfg"* ]] && DOCKER_HOST="$host" docker info >/dev/null 2>&1; then
@@ -160,17 +160,17 @@ pkgs.writeShellApplication {
       ${dockerRunDir} ${dockerDataDir} ${containerdRunDir} ${containerdDataDir}
 
     mkdir -p /run/systemd/system
-    ln -sfn "${dockerSystemdSocketUnit}" "/run/systemd/system/$socket_unit"
-    ln -sfn "${dockerSystemdServiceUnit}" "/run/systemd/system/$service_unit"
-    ln -sfn "${containerdServiceUnit}" "/run/systemd/system/$containerd_unit"
+    ln -sfn "${dockerSystemdSocketUnit}" "/run/systemd/system/$docker_socket_unit"
+    ln -sfn "${dockerSystemdServiceUnit}" "/run/systemd/system/$docker_service_unit"
+    ln -sfn "${containerdServiceUnit}" "/run/systemd/system/$containerd_service_unit"
 
     mkdir -p /nix/var/nix/gcroots
     ln -sfn "${dockerSystemdServiceUnit}" "/nix/var/nix/gcroots/$unit_base"
 
     systemctl daemon-reload
-    systemctl enable --runtime --now "$containerd_unit" >/dev/null
-    systemctl enable --runtime --now "$socket_unit" >/dev/null 2>&1 || true
-    systemctl try-restart "$service_unit" >/dev/null 2>&1 || true
+    systemctl enable --runtime --now "$containerd_service_unit" >/dev/null
+    systemctl enable --runtime --now "$docker_socket_unit" >/dev/null 2>&1 || true
+    systemctl try-restart "$docker_service_unit" >/dev/null 2>&1 || true
 
     docker_ready="false"
     for _ in $(seq 1 120); do
@@ -182,7 +182,7 @@ pkgs.writeShellApplication {
     done
     if [ "$docker_ready" != "true" ]; then
       echo "Error: dockerd not reachable at $host" >&2
-      systemctl status "$service_unit" --no-pager || true
+      systemctl status "$docker_service_unit" --no-pager || true
       exit 1
     fi
 

--- a/runtime/default.nix
+++ b/runtime/default.nix
@@ -162,17 +162,12 @@ pkgs.writeShellApplication {
     systemctl daemon-reload
     systemctl enable --runtime --now "$containerd_service_unit" >/dev/null
     systemctl enable --runtime --now "$docker_socket_unit" >/dev/null 2>&1 || true
-    systemctl try-restart "$docker_service_unit" >/dev/null 2>&1 || true
-
-    docker_ready="false"
-    for _ in $(seq 1 120); do
-      if DOCKER_HOST="$docker_host" docker info >/dev/null 2>&1; then
-        docker_ready="true"
-        break
-      fi
-      sleep 0.25
-    done
-    if [ "$docker_ready" != "true" ]; then
+    if ! timeout 120 systemctl restart "$docker_service_unit" >/dev/null 2>&1; then
+      echo "Error: failed to (re)start $docker_service_unit" >&2
+      systemctl status "$docker_service_unit" --no-pager || true
+      exit 1
+    fi
+    if ! DOCKER_HOST="$docker_host" docker info >/dev/null 2>&1; then
       echo "Error: dockerd not reachable at $docker_host" >&2
       systemctl status "$docker_service_unit" --no-pager || true
       exit 1

--- a/runtime/default.nix
+++ b/runtime/default.nix
@@ -46,6 +46,9 @@ let
       TasksMax = "infinity";
       OOMScoreAdjust = -500;
     };
+    Install = {
+      WantedBy = "multi-user.target";
+    };
   };
 
   runtimePathEnv =
@@ -106,9 +109,6 @@ let
       ExecStart = "${pkgs.docker}/bin/dockerd --config-file=${dockerDaemonJson} -H fd://";
       Environment = runtimePathEnv;
     };
-    Install = {
-      WantedBy = "multi-user.target";
-    };
   });
 
   containerdServiceUnit = toSystemdUnit "${name}-containerd.service" (lib.recursiveUpdate systemdServiceCommon {
@@ -122,9 +122,6 @@ let
       ExecStart = "${pkgs.containerd}/bin/containerd --config ${containerdConfigToml}";
       Environment = runtimePathEnv;
       TimeoutStartSec = 60;
-    };
-    Install = {
-      WantedBy = "multi-user.target";
     };
   });
 

--- a/runtime/default.nix
+++ b/runtime/default.nix
@@ -148,6 +148,8 @@ pkgs.writeShellApplication {
     docker_socket_unit="${name}-docker.socket"
     docker_service_unit="${name}-docker.service"
     containerd_service_unit="${name}-containerd.service"
+    legacy_docker_socket_unit="${name}.socket"
+    legacy_docker_service_unit="${name}.service"
 
     current_service_link="$(readlink -f "/run/systemd/system/$docker_service_unit" 2>/dev/null || true)"
 
@@ -168,8 +170,18 @@ pkgs.writeShellApplication {
     mkdir -p /nix/var/nix/gcroots
     ln -sfn "${dockerSystemdServiceUnit}" "/nix/var/nix/gcroots/${name}"
 
+    # Best-effort migration from pre -docker.{socket,service} unit names.
+    systemctl stop "$legacy_docker_service_unit" >/dev/null 2>&1 || true
+    systemctl stop "$legacy_docker_socket_unit" >/dev/null 2>&1 || true
+    systemctl disable --runtime "$legacy_docker_socket_unit" >/dev/null 2>&1 || true
+
     systemctl daemon-reload
-    systemctl enable --runtime --now "$containerd_service_unit" >/dev/null
+    systemctl enable --runtime "$containerd_service_unit" >/dev/null 2>&1 || true
+    if ! timeout 60 systemctl restart "$containerd_service_unit" >/dev/null; then
+      echo "Error: failed to (re)start $containerd_service_unit" >&2
+      systemctl status "$containerd_service_unit" --no-pager || true
+      exit 1
+    fi
     systemctl enable --runtime --now "$docker_socket_unit" >/dev/null 2>&1 || true
     if ! timeout 60 systemctl restart "$docker_service_unit" >/dev/null 2>&1; then
       echo "Error: failed to (re)start $docker_service_unit" >&2

--- a/runtime/default.nix
+++ b/runtime/default.nix
@@ -2,16 +2,16 @@
 let
   name = "pwn-challenge-runtime";
 
-  dataBase = "/var/lib/pwn.college";
-  runBase = "/run/pwn.college";
+  dataDir = "/var/lib/pwn.college";
+  runDir = "/run/pwn.college";
 
-  dataRoot = "${dataBase}/docker";
-  runRoot = "${runBase}/docker";
-  sockPath = "${runRoot}/docker.sock";
+  dockerDataDir = "${dataDir}/docker";
+  dockerRunDir = "${runDir}/docker";
+  dockerSockPath = "${dockerRunDir}/docker.sock";
 
-  containerdDataRoot = "${dataBase}/containerd";
-  containerdRunRoot = "${runBase}/containerd";
-  containerdSockPath = "${containerdRunRoot}/containerd.sock";
+  containerdDataDir = "${dataDir}/containerd";
+  containerdRunDir = "${runDir}/containerd";
+  containerdSockPath = "${containerdRunDir}/containerd.sock";
   containerdSockAddr = "unix://${containerdSockPath}";
 
   jsonFormat = pkgs.formats.json { };
@@ -37,9 +37,9 @@ let
       '';
 
   dockerDaemonJson = jsonFormat.generate "${name}-docker-daemon.json" {
-    "data-root" = dataRoot;
-    "exec-root" = runRoot;
-    "pidfile" = "${runRoot}/dockerd.pid";
+    "data-root" = dockerDataDir;
+    "exec-root" = dockerRunDir;
+    "pidfile" = "${dockerRunDir}/dockerd.pid";
     "log-driver" = "journald";
     "seccomp-profile" = "${seccompProfile}";
     "containerd" = containerdSockAddr;
@@ -62,8 +62,8 @@ let
   # rather than the host's /var/lib/containerd.
   containerdConfigToml = pkgs.writeText "${name}-containerd-config.toml" ''
     version = 2
-    root = "${containerdDataRoot}"
-    state = "${containerdRunRoot}"
+    root = "${containerdDataDir}"
+    state = "${containerdRunDir}"
 
     [grpc]
       address = "${containerdSockPath}"
@@ -74,7 +74,7 @@ let
       Description = "pwn.college challenge runtime docker socket";
     };
     Socket = {
-      ListenStream = sockPath;
+      ListenStream = dockerSockPath;
       SocketMode = "0666";
     };
     Install = {
@@ -146,7 +146,7 @@ pkgs.writeShellApplication {
     socket_unit="$unit_base.socket"
     service_unit="$unit_base.service"
     containerd_unit="$unit_base-containerd.service"
-    host="unix://${sockPath}"
+    host="unix://${dockerSockPath}"
 
     current_execstart="$(systemctl show -p ExecStart "$service_unit" 2>/dev/null || true)"
     want_cfg="--config-file=${dockerDaemonJson}"
@@ -156,10 +156,10 @@ pkgs.writeShellApplication {
       exit 0
     fi
 
-    install -d -m 0711 -o root -g root ${runRoot}
-    install -d -m 0711 -o root -g root ${dataRoot}
-    install -d -m 0711 -o root -g root ${containerdRunRoot}
-    install -d -m 0711 -o root -g root ${containerdDataRoot}
+    install -d -m 0711 -o root -g root ${dockerRunDir}
+    install -d -m 0711 -o root -g root ${dockerDataDir}
+    install -d -m 0711 -o root -g root ${containerdRunDir}
+    install -d -m 0711 -o root -g root ${containerdDataDir}
 
     mkdir -p /run/systemd/system
     ln -sfn "${systemdSocketUnit}" "/run/systemd/system/$socket_unit"

--- a/runtime/default.nix
+++ b/runtime/default.nix
@@ -166,7 +166,11 @@ pkgs.writeShellApplication {
     ln -sfn "${containerdServiceUnit}" "/run/systemd/system/$containerd_service_unit"
 
     mkdir -p /nix/var/nix/gcroots
-    runtime_store_path="$(readlink -f "$0" 2>/dev/null || echo "$0")"
+    runtime_store_path="$0"
+    if [[ "$runtime_store_path" != /nix/store/* ]]; then
+      echo "Error: expected runtime path under /nix/store, got: $runtime_store_path" >&2
+      exit 1
+    fi
     ln -sfn "$runtime_store_path" "/nix/var/nix/gcroots/${name}"
 
     systemctl daemon-reload

--- a/runtime/default.nix
+++ b/runtime/default.nix
@@ -169,23 +169,20 @@ pkgs.writeShellApplication {
     ln -sfn "${dockerSystemdServiceUnit}" "/nix/var/nix/gcroots/${name}"
 
     systemctl daemon-reload
-    systemctl enable --runtime "$containerd_service_unit" >/dev/null 2>&1 || true
-    if ! timeout 60 systemctl restart "$containerd_service_unit" >/dev/null; then
-      echo "Error: failed to (re)start $containerd_service_unit" >&2
-      systemctl status "$containerd_service_unit" --no-pager >&2 || true
-      exit 1
-    fi
-    systemctl enable --runtime "$docker_socket_unit" >/dev/null 2>&1 || true
-    if ! timeout 60 systemctl restart "$docker_socket_unit" >/dev/null 2>&1; then
-      echo "Error: failed to (re)start $docker_socket_unit" >&2
-      systemctl status "$docker_socket_unit" --no-pager >&2 || true
-      exit 1
-    fi
-    if ! timeout 60 systemctl restart "$docker_service_unit" >/dev/null 2>&1; then
-      echo "Error: failed to (re)start $docker_service_unit" >&2
-      systemctl status "$docker_service_unit" --no-pager >&2 || true
-      exit 1
-    fi
+
+    restart_unit() {
+      local unit="$1"
+      systemctl enable --runtime "$unit" >/dev/null 2>&1 || true
+      if ! timeout 60 systemctl restart "$unit" >/dev/null 2>&1; then
+        echo "Error: failed to (re)start $unit" >&2
+        systemctl status "$unit" --no-pager >&2 || true
+        exit 1
+      fi
+    }
+
+    restart_unit "$containerd_service_unit"
+    restart_unit "$docker_socket_unit"
+    restart_unit "$docker_service_unit"
     if ! timeout 60 env DOCKER_HOST="$docker_host" docker info >/dev/null 2>&1; then
       echo "Error: dockerd not reachable at $docker_host" >&2
       systemctl status "$docker_service_unit" --no-pager >&2 || true

--- a/runtime/default.nix
+++ b/runtime/default.nix
@@ -172,18 +172,26 @@ pkgs.writeShellApplication {
     systemctl enable --runtime "$containerd_service_unit" >/dev/null 2>&1 || true
     if ! timeout 60 systemctl restart "$containerd_service_unit" >/dev/null; then
       echo "Error: failed to (re)start $containerd_service_unit" >&2
-      systemctl status "$containerd_service_unit" --no-pager || true
+      systemctl status "$containerd_service_unit" --no-pager >&2 || true
       exit 1
     fi
     systemctl enable --runtime --now "$docker_socket_unit" >/dev/null 2>&1 || true
     if ! timeout 60 systemctl restart "$docker_service_unit" >/dev/null 2>&1; then
       echo "Error: failed to (re)start $docker_service_unit" >&2
-      systemctl status "$docker_service_unit" --no-pager || true
+      systemctl status "$docker_service_unit" --no-pager >&2 || true
       exit 1
     fi
-    if ! DOCKER_HOST="$docker_host" docker info >/dev/null 2>&1; then
+    docker_ready="false"
+    for _ in $(seq 1 240); do
+      if DOCKER_HOST="$docker_host" docker info >/dev/null 2>&1; then
+        docker_ready="true"
+        break
+      fi
+      sleep 0.25
+    done
+    if [ "$docker_ready" != "true" ]; then
       echo "Error: dockerd not reachable at $docker_host" >&2
-      systemctl status "$docker_service_unit" --no-pager || true
+      systemctl status "$docker_service_unit" --no-pager >&2 || true
       exit 1
     fi
 

--- a/runtime/default.nix
+++ b/runtime/default.nix
@@ -12,7 +12,6 @@ let
   containerdDataDir = "${dataDir}/containerd";
   containerdRunDir = "${runDir}/containerd";
   containerdSockPath = "${containerdRunDir}/containerd.sock";
-  containerdSockAddr = "unix://${containerdSockPath}";
 
   jsonFormat = pkgs.formats.json { };
 
@@ -58,7 +57,7 @@ let
     "pidfile" = "${dockerRunDir}/dockerd.pid";
     "log-driver" = "journald";
     "seccomp-profile" = "${seccompProfile}";
-    "containerd" = containerdSockAddr;
+    "containerd" = "unix://${containerdSockPath}";
 
     "features" = {
       "containerd-snapshotter" = true;

--- a/runtime/default.nix
+++ b/runtime/default.nix
@@ -124,6 +124,7 @@ let
       NotifyAccess = "all";
       ExecStart = "${pkgs.containerd}/bin/containerd --config ${containerdConfigToml}";
       Environment = runtimePathEnv;
+      TimeoutStartSec = 60;
     };
     Install = {
       WantedBy = "multi-user.target";
@@ -169,7 +170,7 @@ pkgs.writeShellApplication {
     ln -sfn "${dockerSystemdServiceUnit}" "/nix/var/nix/gcroots/$unit_base"
 
     systemctl daemon-reload
-    systemctl enable --runtime --now "$containerd_unit" >/dev/null 2>&1 || true
+    systemctl enable --runtime --now "$containerd_unit" >/dev/null
     systemctl enable --runtime --now "$socket_unit" >/dev/null 2>&1 || true
     systemctl try-restart "$service_unit" >/dev/null 2>&1 || true
 

--- a/runtime/default.nix
+++ b/runtime/default.nix
@@ -149,10 +149,12 @@ pkgs.writeShellApplication {
     docker_service_unit="${name}-docker.service"
     containerd_service_unit="${name}-containerd.service"
 
-    current_execstart="$(systemctl show -p ExecStart "$docker_service_unit" 2>/dev/null || true)"
-    want_execstart="${dockerExecStart}"
+    current_service_link="$(readlink -f "/run/systemd/system/$docker_service_unit" 2>/dev/null || true)"
+    current_socket_link="$(readlink -f "/run/systemd/system/$docker_socket_unit" 2>/dev/null || true)"
 
-    if [[ "$current_execstart" == *"$want_execstart"* ]] && DOCKER_HOST="$docker_host" docker info >/dev/null 2>&1; then
+    if [[ "$current_service_link" == "${dockerSystemdServiceUnit}" ]] \
+      && [[ "$current_socket_link" == "${dockerSystemdSocketUnit}" ]] \
+      && DOCKER_HOST="$docker_host" docker info >/dev/null 2>&1; then
       echo "$docker_host"
       exit 0
     fi

--- a/runtime/default.nix
+++ b/runtime/default.nix
@@ -186,15 +186,7 @@ pkgs.writeShellApplication {
       systemctl status "$docker_service_unit" --no-pager >&2 || true
       exit 1
     fi
-    docker_ready="false"
-    for _ in $(seq 1 240); do
-      if DOCKER_HOST="$docker_host" docker info >/dev/null 2>&1; then
-        docker_ready="true"
-        break
-      fi
-      sleep 0.25
-    done
-    if [ "$docker_ready" != "true" ]; then
+    if ! timeout 60 env DOCKER_HOST="$docker_host" docker info >/dev/null 2>&1; then
       echo "Error: dockerd not reachable at $docker_host" >&2
       systemctl status "$docker_service_unit" --no-pager >&2 || true
       exit 1

--- a/runtime/default.nix
+++ b/runtime/default.nix
@@ -35,13 +35,11 @@ let
             'enable_annotations = ["enable_iommu", "virtio_fs_extra_args", "kernel_params", "default_memory"]'
       '';
 
-  runtimePathEnv =
-    "PATH=${pkgs.kata-runtime}/bin:${pkgs.docker}/bin:${pkgs.containerd}/bin:/usr/sbin:/usr/bin:/sbin:/bin";
-
   systemdServiceCommon = {
     Service = {
       Type = "notify";
-      Environment = runtimePathEnv;
+      Environment =
+        "PATH=${pkgs.kata-runtime}/bin:${pkgs.docker}/bin:${pkgs.containerd}/bin:/usr/sbin:/usr/bin:/sbin:/bin";
       Restart = "on-failure";
       TimeoutStartSec = 0;
       Delegate = "yes";

--- a/runtime/default.nix
+++ b/runtime/default.nix
@@ -166,7 +166,8 @@ pkgs.writeShellApplication {
     ln -sfn "${containerdServiceUnit}" "/run/systemd/system/$containerd_service_unit"
 
     mkdir -p /nix/var/nix/gcroots
-    ln -sfn "${dockerSystemdServiceUnit}" "/nix/var/nix/gcroots/${name}"
+    runtime_store_path="$(readlink -f "$0" 2>/dev/null || echo "$0")"
+    ln -sfn "$runtime_store_path" "/nix/var/nix/gcroots/${name}"
 
     systemctl daemon-reload
 

--- a/runtime/default.nix
+++ b/runtime/default.nix
@@ -169,11 +169,35 @@ pkgs.writeShellApplication {
 
     systemctl daemon-reload
     systemctl enable --runtime --now "$containerd_unit" >/dev/null 2>&1 || true
+
+    containerd_ready="false"
+    for _ in $(seq 1 120); do
+      if [ -S ${containerdSockPath} ] && timeout 1 ctr --address ${containerdSockAddr} version >/dev/null 2>&1; then
+        containerd_ready="true"
+        break
+      fi
+      sleep 0.25
+    done
+    if [ "$containerd_ready" != "true" ]; then
+      echo "Error: containerd not reachable at ${containerdSockAddr}" >&2
+      systemctl status "$containerd_unit" --no-pager || true
+      exit 1
+    fi
+
     systemctl enable --runtime --now "$socket_unit" >/dev/null 2>&1 || true
     systemctl try-restart "$service_unit" >/dev/null 2>&1 || true
 
-    if ! DOCKER_HOST="$host" docker info >/dev/null 2>&1; then
+    docker_ready="false"
+    for _ in $(seq 1 120); do
+      if DOCKER_HOST="$host" docker info >/dev/null 2>&1; then
+        docker_ready="true"
+        break
+      fi
+      sleep 0.25
+    done
+    if [ "$docker_ready" != "true" ]; then
       echo "Error: dockerd not reachable at $host" >&2
+      systemctl status "$service_unit" --no-pager || true
       exit 1
     fi
 

--- a/runtime/default.nix
+++ b/runtime/default.nix
@@ -166,12 +166,7 @@ pkgs.writeShellApplication {
     ln -sfn "${containerdServiceUnit}" "/run/systemd/system/$containerd_service_unit"
 
     mkdir -p /nix/var/nix/gcroots
-    runtime_store_path="$0"
-    if [[ "$runtime_store_path" != /nix/store/* ]]; then
-      echo "Error: expected runtime path under /nix/store, got: $runtime_store_path" >&2
-      exit 1
-    fi
-    ln -sfn "$runtime_store_path" "/nix/var/nix/gcroots/${name}"
+    ln -sfn "$0" "/nix/var/nix/gcroots/${name}"
 
     systemctl daemon-reload
 

--- a/runtime/default.nix
+++ b/runtime/default.nix
@@ -73,6 +73,8 @@ let
     };
   };
 
+  dockerExecStart = "${pkgs.docker}/bin/dockerd --config-file=${dockerDaemonJson} -H fd://";
+
   containerdConfigToml = pkgs.writeText "${name}-containerd-config.toml" ''
     version = 2
     root = "${containerdDataDir}"
@@ -103,7 +105,7 @@ let
     };
     Service = {
       Type = "notify";
-      ExecStart = "${pkgs.docker}/bin/dockerd --config-file=${dockerDaemonJson} -H fd://";
+      ExecStart = dockerExecStart;
       Environment = runtimePathEnv;
     };
     Install = {
@@ -148,9 +150,9 @@ pkgs.writeShellApplication {
     containerd_service_unit="${name}-containerd.service"
 
     current_execstart="$(systemctl show -p ExecStart "$docker_service_unit" 2>/dev/null || true)"
-    want_cfg="--config-file=${dockerDaemonJson}"
+    want_execstart="${dockerExecStart}"
 
-    if [[ "$current_execstart" == *"$want_cfg"* ]] && DOCKER_HOST="$docker_host" docker info >/dev/null 2>&1; then
+    if [[ "$current_execstart" == *"$want_execstart"* ]] && DOCKER_HOST="$docker_host" docker info >/dev/null 2>&1; then
       echo "$docker_host"
       exit 0
     fi

--- a/runtime/default.nix
+++ b/runtime/default.nix
@@ -162,7 +162,7 @@ pkgs.writeShellApplication {
     systemctl daemon-reload
     systemctl enable --runtime --now "$containerd_service_unit" >/dev/null
     systemctl enable --runtime --now "$docker_socket_unit" >/dev/null 2>&1 || true
-    if ! timeout 120 systemctl restart "$docker_service_unit" >/dev/null 2>&1; then
+    if ! timeout 60 systemctl restart "$docker_service_unit" >/dev/null 2>&1; then
       echo "Error: failed to (re)start $docker_service_unit" >&2
       systemctl status "$docker_service_unit" --no-pager || true
       exit 1

--- a/runtime/default.nix
+++ b/runtime/default.nix
@@ -36,6 +36,22 @@ let
             'enable_annotations = ["enable_iommu", "virtio_fs_extra_args", "kernel_params", "default_memory"]'
       '';
 
+  systemdServiceCommon = {
+    Service = {
+      Restart = "on-failure";
+      TimeoutStartSec = 0;
+      Delegate = "yes";
+      KillMode = "process";
+      LimitNPROC = "infinity";
+      LimitCORE = "infinity";
+      TasksMax = "infinity";
+      OOMScoreAdjust = -500;
+    };
+  };
+
+  runtimePathEnv =
+    "PATH=${pkgs.kata-runtime}/bin:${pkgs.docker}/bin:${pkgs.containerd}/bin:/usr/sbin:/usr/bin:/sbin:/bin";
+
   dockerDaemonJson = jsonFormat.generate "${name}-docker-daemon.json" {
     "data-root" = dockerDataDir;
     "exec-root" = dockerRunDir;
@@ -82,7 +98,7 @@ let
     };
   };
 
-  dockerSystemdServiceUnit = toSystemdUnit "${name}.service" {
+  dockerSystemdServiceUnit = toSystemdUnit "${name}.service" (lib.recursiveUpdate systemdServiceCommon {
     Unit = {
       Description = "pwn.college challenge runtime docker daemon";
       Requires = [ "${name}.socket" "${name}-containerd.service" ];
@@ -91,22 +107,14 @@ let
     Service = {
       Type = "notify";
       ExecStart = "${pkgs.docker}/bin/dockerd --config-file=${dockerDaemonJson} -H fd://";
-      Environment = "PATH=${pkgs.kata-runtime}/bin:${pkgs.docker}/bin:/usr/sbin:/usr/bin:/sbin:/bin";
-      Restart = "on-failure";
-      TimeoutStartSec = 0;
-      Delegate = "yes";
-      KillMode = "process";
-      LimitNPROC = "infinity";
-      LimitCORE = "infinity";
-      TasksMax = "infinity";
-      OOMScoreAdjust = -500;
+      Environment = runtimePathEnv;
     };
     Install = {
       WantedBy = "multi-user.target";
     };
-  };
+  });
 
-  containerdServiceUnit = toSystemdUnit "${name}-containerd.service" {
+  containerdServiceUnit = toSystemdUnit "${name}-containerd.service" (lib.recursiveUpdate systemdServiceCommon {
     Unit = {
       Description = "pwn.college challenge runtime containerd";
       After = "local-fs.target";
@@ -114,20 +122,12 @@ let
     Service = {
       Type = "simple";
       ExecStart = "${pkgs.containerd}/bin/containerd --config ${containerdConfigToml}";
-      Environment = "PATH=${pkgs.kata-runtime}/bin:${pkgs.containerd}/bin:/usr/sbin:/usr/bin:/sbin:/bin";
-      Restart = "on-failure";
-      TimeoutStartSec = 0;
-      Delegate = "yes";
-      KillMode = "process";
-      LimitNPROC = "infinity";
-      LimitCORE = "infinity";
-      TasksMax = "infinity";
-      OOMScoreAdjust = -500;
+      Environment = runtimePathEnv;
     };
     Install = {
       WantedBy = "multi-user.target";
     };
-  };
+  });
 
 in
 pkgs.writeShellApplication {
@@ -156,10 +156,8 @@ pkgs.writeShellApplication {
       exit 0
     fi
 
-    install -d -m 0711 -o root -g root ${dockerRunDir}
-    install -d -m 0711 -o root -g root ${dockerDataDir}
-    install -d -m 0711 -o root -g root ${containerdRunDir}
-    install -d -m 0711 -o root -g root ${containerdDataDir}
+    install -d -m 0711 -o root -g root \
+      ${dockerRunDir} ${dockerDataDir} ${containerdRunDir} ${containerdDataDir}
 
     mkdir -p /run/systemd/system
     ln -sfn "${dockerSystemdSocketUnit}" "/run/systemd/system/$socket_unit"

--- a/runtime/default.nix
+++ b/runtime/default.nix
@@ -6,6 +6,11 @@ let
   runRoot = "/run/pwn.college/docker";
   sockPath = "${runRoot}/docker.sock";
 
+  containerdDataRoot = "/var/lib/pwn.college/containerd";
+  containerdRunRoot = "/run/pwn.college/containerd";
+  containerdSockPath = "${containerdRunRoot}/containerd.sock";
+  containerdSockAddr = "unix://${containerdSockPath}";
+
   jsonFormat = pkgs.formats.json { };
 
   kataKernel = import ./kernel.nix { inherit pkgs name; };
@@ -34,6 +39,7 @@ let
     "pidfile" = "${runRoot}/dockerd.pid";
     "log-driver" = "journald";
     "seccomp-profile" = "${seccompProfile}";
+    "containerd" = containerdSockAddr;
 
     "features" = {
       "containerd-snapshotter" = true;
@@ -48,6 +54,17 @@ let
       };
     };
   };
+
+  # Run a dedicated containerd so its content store (blobs/sha256/...) lives under /var/lib/pwn.college,
+  # rather than the host's /var/lib/containerd.
+  containerdConfigToml = pkgs.writeText "${name}-containerd-config.toml" ''
+    version = 2
+    root = "${containerdDataRoot}"
+    state = "${containerdRunRoot}"
+
+    [grpc]
+      address = "${containerdSockPath}"
+  '';
 
   systemdSocketUnit = toSystemdUnit "${name}.socket" {
     Unit = {
@@ -65,13 +82,36 @@ let
   systemdServiceUnit = toSystemdUnit "${name}.service" {
     Unit = {
       Description = "pwn.college challenge runtime docker daemon";
-      Requires = "${name}.socket";
-      After = "local-fs.target";
+      Requires = [ "${name}.socket" "${name}-containerd.service" ];
+      After = [ "local-fs.target" "${name}-containerd.service" ];
     };
     Service = {
       Type = "notify";
       ExecStart = "${pkgs.docker}/bin/dockerd --config-file=${dockerDaemonJson} -H fd://";
       Environment = "PATH=${pkgs.kata-runtime}/bin:${pkgs.docker}/bin:/usr/sbin:/usr/bin:/sbin:/bin";
+      Restart = "on-failure";
+      TimeoutStartSec = 0;
+      Delegate = "yes";
+      KillMode = "process";
+      LimitNPROC = "infinity";
+      LimitCORE = "infinity";
+      TasksMax = "infinity";
+      OOMScoreAdjust = -500;
+    };
+    Install = {
+      WantedBy = "multi-user.target";
+    };
+  };
+
+  containerdServiceUnit = toSystemdUnit "${name}-containerd.service" {
+    Unit = {
+      Description = "pwn.college challenge runtime containerd";
+      After = "local-fs.target";
+    };
+    Service = {
+      Type = "simple";
+      ExecStart = "${pkgs.containerd}/bin/containerd --config ${containerdConfigToml}";
+      Environment = "PATH=${pkgs.kata-runtime}/bin:${pkgs.containerd}/bin:/usr/sbin:/usr/bin:/sbin:/bin";
       Restart = "on-failure";
       TimeoutStartSec = 0;
       Delegate = "yes";
@@ -92,6 +132,7 @@ pkgs.writeShellApplication {
   runtimeInputs = with pkgs; [
     bash
     coreutils
+    containerd
     docker
     systemd
   ];
@@ -101,6 +142,7 @@ pkgs.writeShellApplication {
     unit_base="${name}"
     socket_unit="$unit_base.socket"
     service_unit="$unit_base.service"
+    containerd_unit="$unit_base-containerd.service"
     host="unix://${sockPath}"
 
     current_execstart="$(systemctl show -p ExecStart "$service_unit" 2>/dev/null || true)"
@@ -113,15 +155,19 @@ pkgs.writeShellApplication {
 
     install -d -m 0711 -o root -g root ${runRoot}
     install -d -m 0711 -o root -g root ${dataRoot}
+    install -d -m 0711 -o root -g root ${containerdRunRoot}
+    install -d -m 0711 -o root -g root ${containerdDataRoot}
 
     mkdir -p /run/systemd/system
     ln -sfn "${systemdSocketUnit}" "/run/systemd/system/$socket_unit"
     ln -sfn "${systemdServiceUnit}" "/run/systemd/system/$service_unit"
+    ln -sfn "${containerdServiceUnit}" "/run/systemd/system/$containerd_unit"
 
     mkdir -p /nix/var/nix/gcroots
     ln -sfn "${systemdServiceUnit}" "/nix/var/nix/gcroots/$unit_base"
 
     systemctl daemon-reload
+    systemctl enable --runtime --now "$containerd_unit" >/dev/null 2>&1 || true
     systemctl enable --runtime --now "$socket_unit" >/dev/null 2>&1 || true
     systemctl try-restart "$service_unit" >/dev/null 2>&1 || true
 

--- a/runtime/default.nix
+++ b/runtime/default.nix
@@ -115,8 +115,8 @@ let
       After = "local-fs.target";
     };
     Service = {
-      NotifyAccess = "all";
       ExecStart = "${pkgs.containerd}/bin/containerd --config ${containerdConfigToml}";
+      NotifyAccess = "all";
       TimeoutStartSec = 60;
     };
   });

--- a/runtime/default.nix
+++ b/runtime/default.nix
@@ -85,7 +85,7 @@ let
       address = "${containerdSockPath}"
   '';
 
-  dockerSystemdSocketUnit = toSystemdUnit "${name}.socket" {
+  dockerSystemdSocketUnit = toSystemdUnit "${name}-docker.socket" {
     Unit = {
       Description = "pwn.college challenge runtime docker socket";
     };
@@ -98,10 +98,10 @@ let
     };
   };
 
-  dockerSystemdServiceUnit = toSystemdUnit "${name}.service" (lib.recursiveUpdate systemdServiceCommon {
+  dockerSystemdServiceUnit = toSystemdUnit "${name}-docker.service" (lib.recursiveUpdate systemdServiceCommon {
     Unit = {
       Description = "pwn.college challenge runtime docker daemon";
-      Requires = [ "${name}.socket" "${name}-containerd.service" ];
+      Requires = [ "${name}-docker.socket" "${name}-containerd.service" ];
       After = [ "local-fs.target" "${name}-containerd.service" ];
     };
     Service = {
@@ -145,8 +145,8 @@ pkgs.writeShellApplication {
     set -euo pipefail
 
     unit_base="${name}"
-    socket_unit="$unit_base.socket"
-    service_unit="$unit_base.service"
+    socket_unit="$unit_base-docker.socket"
+    service_unit="$unit_base-docker.service"
     containerd_unit="$unit_base-containerd.service"
     host="unix://${dockerSockPath}"
 

--- a/runtime/default.nix
+++ b/runtime/default.nix
@@ -35,8 +35,13 @@ let
             'enable_annotations = ["enable_iommu", "virtio_fs_extra_args", "kernel_params", "default_memory"]'
       '';
 
+  runtimePathEnv =
+    "PATH=${pkgs.kata-runtime}/bin:${pkgs.docker}/bin:${pkgs.containerd}/bin:/usr/sbin:/usr/bin:/sbin:/bin";
+
   systemdServiceCommon = {
     Service = {
+      Type = "notify";
+      Environment = runtimePathEnv;
       Restart = "on-failure";
       TimeoutStartSec = 0;
       Delegate = "yes";
@@ -50,9 +55,6 @@ let
       WantedBy = "multi-user.target";
     };
   };
-
-  runtimePathEnv =
-    "PATH=${pkgs.kata-runtime}/bin:${pkgs.docker}/bin:${pkgs.containerd}/bin:/usr/sbin:/usr/bin:/sbin:/bin";
 
   dockerDaemonJson = jsonFormat.generate "${name}-docker-daemon.json" {
     "data-root" = dockerDataDir;
@@ -105,9 +107,7 @@ let
       After = [ "local-fs.target" "${name}-containerd.service" ];
     };
     Service = {
-      Type = "notify";
       ExecStart = "${pkgs.docker}/bin/dockerd --config-file=${dockerDaemonJson} -H fd://";
-      Environment = runtimePathEnv;
     };
   });
 
@@ -117,10 +117,8 @@ let
       After = "local-fs.target";
     };
     Service = {
-      Type = "notify";
       NotifyAccess = "all";
       ExecStart = "${pkgs.containerd}/bin/containerd --config ${containerdConfigToml}";
-      Environment = runtimePathEnv;
       TimeoutStartSec = 60;
     };
   });

--- a/runtime/default.nix
+++ b/runtime/default.nix
@@ -22,19 +22,6 @@ let
     unitFileName: sections:
     pkgs.writeText unitFileName (lib.generators.toINI { listsAsDuplicateKeys = true; } sections);
 
-  kataConfigToml =
-    pkgs.runCommand "${name}-kata-config.toml" { nativeBuildInputs = [ pkgs.gawk ]; }
-      ''
-        kernel_line="$(awk '$1 == "kernel" { print; exit }' ${pkgs.kata-runtime}/share/defaults/kata-containers/configuration.toml)"
-        substitute ${pkgs.kata-runtime}/share/defaults/kata-containers/configuration.toml "$out" \
-          --replace-fail \
-            "$kernel_line" \
-            'kernel = "${kataKernel}/share/kata-containers/vmlinux.container"' \
-          --replace-fail \
-            'enable_annotations = ["enable_iommu", "virtio_fs_extra_args", "kernel_params"]' \
-            'enable_annotations = ["enable_iommu", "virtio_fs_extra_args", "kernel_params", "default_memory"]'
-      '';
-
   systemdServiceCommon = {
     Service = {
       Type = "notify";
@@ -53,6 +40,19 @@ let
       WantedBy = "multi-user.target";
     };
   };
+
+  kataConfigToml =
+    pkgs.runCommand "${name}-kata-config.toml" { nativeBuildInputs = [ pkgs.gawk ]; }
+      ''
+        kernel_line="$(awk '$1 == "kernel" { print; exit }' ${pkgs.kata-runtime}/share/defaults/kata-containers/configuration.toml)"
+        substitute ${pkgs.kata-runtime}/share/defaults/kata-containers/configuration.toml "$out" \
+          --replace-fail \
+            "$kernel_line" \
+            'kernel = "${kataKernel}/share/kata-containers/vmlinux.container"' \
+          --replace-fail \
+            'enable_annotations = ["enable_iommu", "virtio_fs_extra_args", "kernel_params"]' \
+            'enable_annotations = ["enable_iommu", "virtio_fs_extra_args", "kernel_params", "default_memory"]'
+      '';
 
   dockerDaemonJson = jsonFormat.generate "${name}-docker-daemon.json" {
     "data-root" = dockerDataDir;
@@ -75,15 +75,6 @@ let
       };
     };
   };
-
-  containerdConfigToml = pkgs.writeText "${name}-containerd-config.toml" ''
-    version = 2
-    root = "${containerdDataDir}"
-    state = "${containerdRunDir}"
-
-    [grpc]
-      address = "${containerdSockPath}"
-  '';
 
   dockerSystemdSocketUnit = toSystemdUnit "${name}-docker.socket" {
     Unit = {
@@ -108,6 +99,15 @@ let
       ExecStart = "${pkgs.docker}/bin/dockerd --config-file=${dockerDaemonJson} -H fd://";
     };
   });
+
+  containerdConfigToml = pkgs.writeText "${name}-containerd-config.toml" ''
+    version = 2
+    root = "${containerdDataDir}"
+    state = "${containerdRunDir}"
+
+    [grpc]
+      address = "${containerdSockPath}"
+  '';
 
   containerdServiceUnit = toSystemdUnit "${name}-containerd.service" (lib.recursiveUpdate systemdServiceCommon {
     Unit = {

--- a/runtime/default.nix
+++ b/runtime/default.nix
@@ -120,7 +120,8 @@ let
       After = "local-fs.target";
     };
     Service = {
-      Type = "simple";
+      Type = "notify";
+      NotifyAccess = "all";
       ExecStart = "${pkgs.containerd}/bin/containerd --config ${containerdConfigToml}";
       Environment = runtimePathEnv;
     };
@@ -169,21 +170,6 @@ pkgs.writeShellApplication {
 
     systemctl daemon-reload
     systemctl enable --runtime --now "$containerd_unit" >/dev/null 2>&1 || true
-
-    containerd_ready="false"
-    for _ in $(seq 1 120); do
-      if [ -S ${containerdSockPath} ] && timeout 1 ctr --address ${containerdSockAddr} version >/dev/null 2>&1; then
-        containerd_ready="true"
-        break
-      fi
-      sleep 0.25
-    done
-    if [ "$containerd_ready" != "true" ]; then
-      echo "Error: containerd not reachable at ${containerdSockAddr}" >&2
-      systemctl status "$containerd_unit" --no-pager || true
-      exit 1
-    fi
-
     systemctl enable --runtime --now "$socket_unit" >/dev/null 2>&1 || true
     systemctl try-restart "$service_unit" >/dev/null 2>&1 || true
 

--- a/runtime/default.nix
+++ b/runtime/default.nix
@@ -73,8 +73,6 @@ let
     };
   };
 
-  dockerExecStart = "${pkgs.docker}/bin/dockerd --config-file=${dockerDaemonJson} -H fd://";
-
   containerdConfigToml = pkgs.writeText "${name}-containerd-config.toml" ''
     version = 2
     root = "${containerdDataDir}"
@@ -105,7 +103,7 @@ let
     };
     Service = {
       Type = "notify";
-      ExecStart = dockerExecStart;
+      ExecStart = "${pkgs.docker}/bin/dockerd --config-file=${dockerDaemonJson} -H fd://";
       Environment = runtimePathEnv;
     };
     Install = {

--- a/runtime/default.nix
+++ b/runtime/default.nix
@@ -69,7 +69,7 @@ let
       address = "${containerdSockPath}"
   '';
 
-  systemdSocketUnit = toSystemdUnit "${name}.socket" {
+  dockerSystemdSocketUnit = toSystemdUnit "${name}.socket" {
     Unit = {
       Description = "pwn.college challenge runtime docker socket";
     };
@@ -82,7 +82,7 @@ let
     };
   };
 
-  systemdServiceUnit = toSystemdUnit "${name}.service" {
+  dockerSystemdServiceUnit = toSystemdUnit "${name}.service" {
     Unit = {
       Description = "pwn.college challenge runtime docker daemon";
       Requires = [ "${name}.socket" "${name}-containerd.service" ];
@@ -162,12 +162,12 @@ pkgs.writeShellApplication {
     install -d -m 0711 -o root -g root ${containerdDataDir}
 
     mkdir -p /run/systemd/system
-    ln -sfn "${systemdSocketUnit}" "/run/systemd/system/$socket_unit"
-    ln -sfn "${systemdServiceUnit}" "/run/systemd/system/$service_unit"
+    ln -sfn "${dockerSystemdSocketUnit}" "/run/systemd/system/$socket_unit"
+    ln -sfn "${dockerSystemdServiceUnit}" "/run/systemd/system/$service_unit"
     ln -sfn "${containerdServiceUnit}" "/run/systemd/system/$containerd_unit"
 
     mkdir -p /nix/var/nix/gcroots
-    ln -sfn "${systemdServiceUnit}" "/nix/var/nix/gcroots/$unit_base"
+    ln -sfn "${dockerSystemdServiceUnit}" "/nix/var/nix/gcroots/$unit_base"
 
     systemctl daemon-reload
     systemctl enable --runtime --now "$containerd_unit" >/dev/null 2>&1 || true

--- a/runtime/default.nix
+++ b/runtime/default.nix
@@ -175,7 +175,12 @@ pkgs.writeShellApplication {
       systemctl status "$containerd_service_unit" --no-pager >&2 || true
       exit 1
     fi
-    systemctl enable --runtime --now "$docker_socket_unit" >/dev/null 2>&1 || true
+    systemctl enable --runtime "$docker_socket_unit" >/dev/null 2>&1 || true
+    if ! timeout 60 systemctl restart "$docker_socket_unit" >/dev/null 2>&1; then
+      echo "Error: failed to (re)start $docker_socket_unit" >&2
+      systemctl status "$docker_socket_unit" --no-pager >&2 || true
+      exit 1
+    fi
     if ! timeout 60 systemctl restart "$docker_service_unit" >/dev/null 2>&1; then
       echo "Error: failed to (re)start $docker_service_unit" >&2
       systemctl status "$docker_service_unit" --no-pager >&2 || true

--- a/runtime/default.nix
+++ b/runtime/default.nix
@@ -74,8 +74,6 @@ let
     };
   };
 
-  # Run a dedicated containerd so its content store (blobs/sha256/...) lives under /var/lib/pwn.college,
-  # rather than the host's /var/lib/containerd.
   containerdConfigToml = pkgs.writeText "${name}-containerd-config.toml" ''
     version = 2
     root = "${containerdDataDir}"

--- a/runtime/default.nix
+++ b/runtime/default.nix
@@ -150,10 +150,8 @@ pkgs.writeShellApplication {
     containerd_service_unit="${name}-containerd.service"
 
     current_service_link="$(readlink -f "/run/systemd/system/$docker_service_unit" 2>/dev/null || true)"
-    current_socket_link="$(readlink -f "/run/systemd/system/$docker_socket_unit" 2>/dev/null || true)"
 
     if [[ "$current_service_link" == "${dockerSystemdServiceUnit}" ]] \
-      && [[ "$current_socket_link" == "${dockerSystemdSocketUnit}" ]] \
       && DOCKER_HOST="$docker_host" docker info >/dev/null 2>&1; then
       echo "$docker_host"
       exit 0

--- a/runtime/default.nix
+++ b/runtime/default.nix
@@ -141,16 +141,17 @@ pkgs.writeShellApplication {
   text = ''
     set -euo pipefail
 
+    docker_host="unix://${dockerSockPath}"
+
     docker_socket_unit="${name}-docker.socket"
     docker_service_unit="${name}-docker.service"
     containerd_service_unit="${name}-containerd.service"
-    host="unix://${dockerSockPath}"
 
     current_execstart="$(systemctl show -p ExecStart "$docker_service_unit" 2>/dev/null || true)"
     want_cfg="--config-file=${dockerDaemonJson}"
 
-    if [[ "$current_execstart" == *"$want_cfg"* ]] && DOCKER_HOST="$host" docker info >/dev/null 2>&1; then
-      echo "$host"
+    if [[ "$current_execstart" == *"$want_cfg"* ]] && DOCKER_HOST="$docker_host" docker info >/dev/null 2>&1; then
+      echo "$docker_host"
       exit 0
     fi
 
@@ -172,18 +173,18 @@ pkgs.writeShellApplication {
 
     docker_ready="false"
     for _ in $(seq 1 120); do
-      if DOCKER_HOST="$host" docker info >/dev/null 2>&1; then
+      if DOCKER_HOST="$docker_host" docker info >/dev/null 2>&1; then
         docker_ready="true"
         break
       fi
       sleep 0.25
     done
     if [ "$docker_ready" != "true" ]; then
-      echo "Error: dockerd not reachable at $host" >&2
+      echo "Error: dockerd not reachable at $docker_host" >&2
       systemctl status "$docker_service_unit" --no-pager || true
       exit 1
     fi
 
-    echo "$host"
+    echo "$docker_host"
   '';
 }

--- a/runtime/default.nix
+++ b/runtime/default.nix
@@ -135,8 +135,8 @@ pkgs.writeShellApplication {
   inherit name;
   runtimeInputs = with pkgs; [
     bash
-    coreutils
     containerd
+    coreutils
     docker
     systemd
   ];


### PR DESCRIPTION
Start a dedicated containerd for the pwn challenge runtime with root/state under `/var/lib/pwn.college` and `/run/pwn.college`, and point dockerd at its socket.

This keeps the containerd content store (`blobs/sha256/...`) out of the host `/var/lib/containerd` and under `/var/lib/pwn.college` (symlinked to `/mnt/pwn.college` on runners).

No CI publishing changes in this PR.

## Notes
- Previously, CI tried to find containerd blobs under Docker root:
  - `$(docker info --format '{{.DockerRootDir}}')/containerd/daemon/io.containerd.content.v1.content/blobs/sha256/...`
- But on GitHub Actions runners, the containerd content store blobs were actually at:
  - `/var/lib/containerd/io.containerd.content.v1.content/blobs/sha256/...`
- With this PR’s dedicated containerd, the content store will be under:
  - `/var/lib/pwn.college/containerd/io.containerd.content.v1.content/blobs/sha256/...`

## Migration (no legacy code kept)
If you previously ran the old runtime units (pre `*-docker.service/socket` rename), run this once before `nix develop`:

```bash
sudo systemctl stop pwn-challenge-runtime.service pwn-challenge-runtime.socket || true
sudo systemctl disable --runtime pwn-challenge-runtime.service pwn-challenge-runtime.socket || true
sudo systemctl reset-failed pwn-challenge-runtime.service pwn-challenge-runtime.socket || true

nix develop
```

If you see build errors like `failed to get reader from content store ... not found` after switching to the dedicated containerd, your old build cache may reference blobs from a previous content store. A one-time cleanup fixes it:

```bash
sudo systemctl stop \
  pwn-challenge-runtime-docker.service \
  pwn-challenge-runtime-docker.socket \
  pwn-challenge-runtime-containerd.service \
  || true

sudo rm -rf \
  /var/lib/pwn.college/docker \
  /var/lib/pwn.college/containerd \
  /run/pwn.college/docker \
  /run/pwn.college/containerd
```
