### PR TITLE
ci: fix publish blob location

### DIFF
--- a/.github/workflows/publish-challenges.yml
+++ b/.github/workflows/publish-challenges.yml
@@ -62,7 +62,7 @@ jobs:
         RCLONE_CONFIG_R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY }}
         RCLONE_CONFIG_R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_KEY }}
       run: |
-        containerd_blobs_dir="/var/lib/pwn.college/containerd/io.containerd.content.v1.content/blobs"
+        containerd_blobs_dir="/mnt/pwn.college/containerd/io.containerd.content.v1.content/blobs"
         publish_blobs_dir="/mnt/publish/blobs"
         publish_manifests_dir="/mnt/publish/manifests"
         sudo mkdir -p "$publish_blobs_dir" "$publish_manifests_dir"

--- a/.github/workflows/publish-challenges.yml
+++ b/.github/workflows/publish-challenges.yml
@@ -62,8 +62,7 @@ jobs:
         RCLONE_CONFIG_R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY }}
         RCLONE_CONFIG_R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_KEY }}
       run: |
-        containerd_blobs_dir="/var/lib/pwn.college/containerd/io.containerd.content.v1.content/blobs"
-        [ -d "$containerd_blobs_dir" ] || containerd_blobs_dir="/var/lib/containerd/io.containerd.content.v1.content/blobs"
+        containerd_blobs_dir="/var/lib/containerd/io.containerd.content.v1.content/blobs"
         publish_blobs_dir="/mnt/publish/blobs"
         publish_manifests_dir="/mnt/publish/manifests"
         sudo mkdir -p "$publish_blobs_dir" "$publish_manifests_dir"

--- a/.github/workflows/publish-challenges.yml
+++ b/.github/workflows/publish-challenges.yml
@@ -62,7 +62,8 @@ jobs:
         RCLONE_CONFIG_R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY }}
         RCLONE_CONFIG_R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_KEY }}
       run: |
-        containerd_blobs_dir="$(docker info --format '{{.DockerRootDir}}')/containerd/daemon/io.containerd.content.v1.content/blobs"
+        containerd_blobs_dir="/var/lib/pwn.college/containerd/io.containerd.content.v1.content/blobs"
+        [ -d "$containerd_blobs_dir" ] || containerd_blobs_dir="/var/lib/containerd/io.containerd.content.v1.content/blobs"
         publish_blobs_dir="/mnt/publish/blobs"
         publish_manifests_dir="/mnt/publish/manifests"
         sudo mkdir -p "$publish_blobs_dir" "$publish_manifests_dir"

--- a/.github/workflows/publish-challenges.yml
+++ b/.github/workflows/publish-challenges.yml
@@ -62,7 +62,7 @@ jobs:
         RCLONE_CONFIG_R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY }}
         RCLONE_CONFIG_R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_KEY }}
       run: |
-        containerd_blobs_dir="/var/lib/containerd/io.containerd.content.v1.content/blobs"
+        containerd_blobs_dir="/var/lib/pwn.college/containerd/io.containerd.content.v1.content/blobs"
         publish_blobs_dir="/mnt/publish/blobs"
         publish_manifests_dir="/mnt/publish/manifests"
         sudo mkdir -p "$publish_blobs_dir" "$publish_manifests_dir"


### PR DESCRIPTION
Fix publish blob discovery: with the dedicated runtime containerd, containerd content store blobs are under /mnt/pwn.college/containerd (because setup-challenge-runtime symlinks /var/lib/pwn.college -> /mnt/pwn.college), not under "/var/lib/docker/containerd/daemon/...".

Depends on the runtime change that runs containerd with root/state under /var/lib/pwn.college (/run/pwn.college).