### PR TITLE
ci: automatically retry flaky tests and limit test duration

### DIFF
--- a/.github/actions/test-challenges/action.yml
+++ b/.github/actions/test-challenges/action.yml
@@ -36,6 +36,17 @@ runs:
             | xargs -r rm -f
         fi
 
+    - name: Validate dojo.yml
+      shell: 'nix develop -c bash -euo pipefail {0}'
+      env:
+        CHALLENGES_DIR: challenges/${{ inputs.challenges }}
+      run: |
+        if [ -f "$CHALLENGES_DIR/dojo.yml" ]; then
+          echo "::group::Validating dojo.yml"
+          ./tools/dojo/parse-dojo-yml "$CHALLENGES_DIR/dojo.yml"
+          echo "::endgroup::"
+        fi
+
     - name: Test challenges
       shell: 'nix develop -c bash -euo pipefail {0}'
       env:
@@ -43,11 +54,6 @@ runs:
         MODIFIED_SINCE: ${{ inputs.modified_since_ref }}
       run: |
         JOBS=$(( $(nproc) * 2 ))
-        if [ -f "$CHALLENGES_DIR/dojo.yml" ]; then
-          echo "::group::Validating dojo.yml"
-          ./tools/dojo/parse-dojo-yml "$CHALLENGES_DIR/dojo.yml"
-          echo "::endgroup::"
-        fi
         echo "::group::Challenges to be tested"
         ./pwnshop list "$CHALLENGES_DIR" --modified-since="$MODIFIED_SINCE"
         echo "::endgroup::"

--- a/.github/actions/test-challenges/action.yml
+++ b/.github/actions/test-challenges/action.yml
@@ -53,11 +53,10 @@ runs:
         CHALLENGES_DIR: challenges/${{ inputs.challenges }}
         MODIFIED_SINCE: ${{ inputs.modified_since_ref }}
       run: |
-        JOBS=$(( $(nproc) * 2 ))
         echo "::group::Challenges to be tested"
         ./pwnshop list "$CHALLENGES_DIR" --modified-since="$MODIFIED_SINCE"
         echo "::endgroup::"
 
         echo "::group::Testing challenges"
-        ./pwnshop test --silent-failures --attempts 5 --jobs "$JOBS" --modified-since="$MODIFIED_SINCE" "$CHALLENGES_DIR"
+        ./pwnshop test --silent-failures --attempts 5 --jobs "$(( $(nproc) * 2 ))" --modified-since="$MODIFIED_SINCE" "$CHALLENGES_DIR"
         echo "::endgroup::"

--- a/.github/actions/test-challenges/action.yml
+++ b/.github/actions/test-challenges/action.yml
@@ -58,5 +58,5 @@ runs:
         echo "::endgroup::"
 
         echo "::group::Testing challenges"
-        ./pwnshop test --silent-failures --jobs "$(( $(nproc) * 2 ))" --attempts 5 --modified-since="$MODIFIED_SINCE" "$CHALLENGES_DIR"
+        ./pwnshop test --modified-since="$MODIFIED_SINCE" --jobs "$(( $(nproc) * 2 ))" --attempts 5 --timeout 120 --silent-failures "$CHALLENGES_DIR"
         echo "::endgroup::"

--- a/.github/actions/test-challenges/action.yml
+++ b/.github/actions/test-challenges/action.yml
@@ -58,5 +58,5 @@ runs:
         echo "::endgroup::"
 
         echo "::group::Testing challenges"
-        ./pwnshop test --silent-failures --attempts 5 --jobs "$(( $(nproc) * 2 ))" --modified-since="$MODIFIED_SINCE" "$CHALLENGES_DIR"
+        ./pwnshop test --silent-failures --jobs "$(( $(nproc) * 2 ))" --attempts 5 --modified-since="$MODIFIED_SINCE" "$CHALLENGES_DIR"
         echo "::endgroup::"

--- a/.github/actions/test-challenges/action.yml
+++ b/.github/actions/test-challenges/action.yml
@@ -58,5 +58,11 @@ runs:
         echo "::endgroup::"
 
         echo "::group::Testing challenges"
-        ./pwnshop test --modified-since="$MODIFIED_SINCE" --jobs "$(( $(nproc) * 2 ))" --attempts 5 --timeout 120 --silent-failures "$CHALLENGES_DIR"
+        ./pwnshop test \
+          --modified-since="$MODIFIED_SINCE" \
+          --jobs "$(( $(nproc) * 2 ))" \
+          --attempts 5 \
+          --timeout 120 \
+          --silent-failures \
+          "$CHALLENGES_DIR"
         echo "::endgroup::"

--- a/.github/actions/test-challenges/action.yml
+++ b/.github/actions/test-challenges/action.yml
@@ -53,5 +53,5 @@ runs:
         echo "::endgroup::"
 
         echo "::group::Testing challenges"
-        ./pwnshop test --silent-failures --jobs "$JOBS" --modified-since="$MODIFIED_SINCE" "$CHALLENGES_DIR"
+        ./pwnshop test --silent-failures --retry 5 --jobs "$JOBS" --modified-since="$MODIFIED_SINCE" "$CHALLENGES_DIR"
         echo "::endgroup::"

--- a/.github/actions/test-challenges/action.yml
+++ b/.github/actions/test-challenges/action.yml
@@ -53,5 +53,5 @@ runs:
         echo "::endgroup::"
 
         echo "::group::Testing challenges"
-        ./pwnshop test --silent-failures --retry 5 --jobs "$JOBS" --modified-since="$MODIFIED_SINCE" "$CHALLENGES_DIR"
+        ./pwnshop test --silent-failures --attempts 5 --jobs "$JOBS" --modified-since="$MODIFIED_SINCE" "$CHALLENGES_DIR"
         echo "::endgroup::"

--- a/tools/pwnshop/src/pwnshop/commands/test.py
+++ b/tools/pwnshop/src/pwnshop/commands/test.py
@@ -40,12 +40,12 @@ logger = logging.getLogger(__name__)
     help="Write failure output to DIR/challenge/test.log files.",
 )
 @click.option(
-    "--retry",
+    "--attempts",
     metavar="N",
     type=click.IntRange(1, None),
     default=1,
     show_default=True,
-    help="Run each test up to N times until it succeeds.",
+    help="Run each test up to N attempts until it succeeds.",
 )
 @click.option("--silent-failures", is_flag=True, help="Do not print failing test output to stdout/stderr.")
 @click.argument(
@@ -60,7 +60,7 @@ logger = logging.getLogger(__name__)
         resolve_path=False,
     ),
 )
-def test_command(targets, modified_since, jobs, require_tests, test_timeout, log_failures, retry, silent_failures):
+def test_command(targets, modified_since, jobs, require_tests, test_timeout, log_failures, attempts, silent_failures):
     """Test one or more challenges."""
     if not (challenge_paths := lib.resolve_targets(targets, modified_since=modified_since)):
         if modified_since:
@@ -90,8 +90,10 @@ def test_command(targets, modified_since, jobs, require_tests, test_timeout, log
                 passed = False
                 last_output = ""
                 failed_attempt_outputs = []
-                for attempt in range(1, retry + 1):
-                    logger.debug("running test %s in %s (attempt %d/%d)", test_name, challenge_path, attempt, retry)
+                for attempt in range(1, attempts + 1):
+                    logger.debug(
+                        "running test %s in %s (attempt %d/%d)", test_name, challenge_path, attempt, attempts
+                    )
                     with lib.run_challenge(challenge_path, image_id, volumes=[test]) as (container, _):
                         try:
                             run = subprocess.run(
@@ -108,7 +110,7 @@ def test_command(targets, modified_since, jobs, require_tests, test_timeout, log
                                 test_timeout,
                                 challenge_path,
                                 attempt,
-                                retry,
+                                attempts,
                             )
                             last_output = f"TIMEOUT after {test_timeout}s\n{e.stdout or ''}"
                             passed = False
@@ -121,20 +123,28 @@ def test_command(targets, modified_since, jobs, require_tests, test_timeout, log
                                 "PASSED" if passed else "FAILED",
                                 run.returncode,
                                 attempt,
-                                retry,
+                                attempts,
                             )
                     if passed:
                         if attempt > 1:
-                            logger.info("test %s passed on attempt %d/%d in %s", test_name, attempt, retry, challenge_path)
+                            logger.info(
+                                "test %s passed on attempt %d/%d in %s",
+                                test_name,
+                                attempt,
+                                attempts,
+                                challenge_path,
+                            )
                         break
 
-                    if retry > 1:
-                        failed_attempt_outputs.append(f"=== attempt {attempt}/{retry} ===\n{last_output}")
+                    if attempts > 1:
+                        failed_attempt_outputs.append(f"=== attempt {attempt}/{attempts} ===\n{last_output}")
                     else:
                         failed_attempt_outputs.append(last_output)
 
                 if not passed:
-                    results.append((test_name, False, "\n".join(failed_attempt_outputs) if retry > 1 else last_output))
+                    results.append(
+                        (test_name, False, "\n".join(failed_attempt_outputs) if attempts > 1 else last_output)
+                    )
                     continue
 
                 results.append((test_name, True, last_output))

--- a/tools/pwnshop/src/pwnshop/commands/test.py
+++ b/tools/pwnshop/src/pwnshop/commands/test.py
@@ -25,20 +25,6 @@ logger = logging.getLogger(__name__)
 @click.command("test")
 @click.option("--modified-since", metavar="REF", help="Only include challenges changed versus REF.")
 @click.option("--jobs", "-j", metavar="N", type=click.IntRange(1, None), help="Parallel challenges (default: cores).")
-@click.option("--require-tests", is_flag=True, help="Fail if any challenge has no tests.")
-@click.option(
-    "--test-timeout",
-    metavar="N",
-    type=click.IntRange(1, None),
-    default=None,
-    help="Timeout in seconds for each individual test.",
-)
-@click.option(
-    "--log-failures",
-    metavar="DIR",
-    type=click.Path(path_type=pathlib.Path, file_okay=False, resolve_path=True),
-    help="Write failure output to DIR/challenge/test.log files.",
-)
 @click.option(
     "--attempts",
     metavar="N",
@@ -46,6 +32,20 @@ logger = logging.getLogger(__name__)
     default=1,
     show_default=True,
     help="Run each test up to N attempts until it succeeds.",
+)
+@click.option(
+    "--timeout",
+    metavar="N",
+    type=click.IntRange(1, None),
+    default=None,
+    help="Timeout in seconds for each individual test.",
+)
+@click.option("--require-tests", is_flag=True, help="Fail if any challenge has no tests.")
+@click.option(
+    "--log-failures",
+    metavar="DIR",
+    type=click.Path(path_type=pathlib.Path, file_okay=False, resolve_path=True),
+    help="Write failure output to DIR/challenge/test.log files.",
 )
 @click.option("--silent-failures", is_flag=True, help="Do not print failing test output to stdout/stderr.")
 @click.argument(
@@ -60,7 +60,7 @@ logger = logging.getLogger(__name__)
         resolve_path=False,
     ),
 )
-def test_command(targets, modified_since, jobs, require_tests, test_timeout, log_failures, attempts, silent_failures):
+def test_command(targets, modified_since, jobs, attempts, timeout, require_tests, log_failures, silent_failures):
     """Test one or more challenges."""
     if not (challenge_paths := lib.resolve_targets(targets, modified_since=modified_since)):
         if modified_since:
@@ -99,18 +99,18 @@ def test_command(targets, modified_since, jobs, require_tests, test_timeout, log
                                 stdout=subprocess.PIPE,
                                 stderr=subprocess.STDOUT,
                                 text=True,
-                                timeout=test_timeout,
+                                timeout=timeout,
                             )
                         except subprocess.TimeoutExpired as e:
                             logger.warning(
                                 "test %s timed out after %ds in %s (attempt %d/%d)",
                                 test_name,
-                                test_timeout,
+                                timeout,
                                 challenge_path,
                                 attempt,
                                 attempts,
                             )
-                            last_output = f"TIMEOUT after {test_timeout}s\n{e.stdout or ''}"
+                            last_output = f"TIMEOUT after {timeout}s\n{e.stdout or ''}"
                             passed = False
                         else:
                             passed = run.returncode == 0

--- a/tools/pwnshop/src/pwnshop/commands/test.py
+++ b/tools/pwnshop/src/pwnshop/commands/test.py
@@ -39,6 +39,14 @@ logger = logging.getLogger(__name__)
     type=click.Path(path_type=pathlib.Path, file_okay=False, resolve_path=True),
     help="Write failure output to DIR/challenge/test.log files.",
 )
+@click.option(
+    "--retry",
+    metavar="N",
+    type=click.IntRange(1, None),
+    default=1,
+    show_default=True,
+    help="Run each test up to N times until it succeeds.",
+)
 @click.option("--silent-failures", is_flag=True, help="Do not print failing test output to stdout/stderr.")
 @click.argument(
     "targets",
@@ -52,7 +60,7 @@ logger = logging.getLogger(__name__)
         resolve_path=False,
     ),
 )
-def test_command(targets, modified_since, jobs, require_tests, test_timeout, log_failures, silent_failures):
+def test_command(targets, modified_since, jobs, require_tests, test_timeout, log_failures, retry, silent_failures):
     """Test one or more challenges."""
     if not (challenge_paths := lib.resolve_targets(targets, modified_since=modified_since)):
         if modified_since:
@@ -79,22 +87,57 @@ def test_command(targets, modified_since, jobs, require_tests, test_timeout, log
             for test in tests:
                 test_name = test.relative_to(rendered)
                 logger.debug("running test %s in %s", test_name, challenge_path)
-                with lib.run_challenge(challenge_path, image_id, volumes=[test]) as (container, _):
-                    try:
-                        run = subprocess.run(
-                            ["docker", "exec", "--user=1000:1000", container, f"{test}"],
-                            stdout=subprocess.PIPE,
-                            stderr=subprocess.STDOUT,
-                            text=True,
-                            timeout=test_timeout,
-                        )
-                    except subprocess.TimeoutExpired as e:
-                        logger.warning("test %s timed out after %ds in %s", test_name, test_timeout, challenge_path)
-                        results.append((test_name, False, f"TIMEOUT after {test_timeout}s\n{e.stdout or ''}"))
-                        continue
-                passed = run.returncode == 0
-                logger.debug("test %s %s (rc=%d)", test_name, "PASSED" if passed else "FAILED", run.returncode)
-                results.append((test_name, passed, run.stdout or ""))
+                passed = False
+                last_output = ""
+                failed_attempt_outputs = []
+                for attempt in range(1, retry + 1):
+                    logger.debug("running test %s in %s (attempt %d/%d)", test_name, challenge_path, attempt, retry)
+                    with lib.run_challenge(challenge_path, image_id, volumes=[test]) as (container, _):
+                        try:
+                            run = subprocess.run(
+                                ["docker", "exec", "--user=1000:1000", container, f"{test}"],
+                                stdout=subprocess.PIPE,
+                                stderr=subprocess.STDOUT,
+                                text=True,
+                                timeout=test_timeout,
+                            )
+                        except subprocess.TimeoutExpired as e:
+                            logger.warning(
+                                "test %s timed out after %ds in %s (attempt %d/%d)",
+                                test_name,
+                                test_timeout,
+                                challenge_path,
+                                attempt,
+                                retry,
+                            )
+                            last_output = f"TIMEOUT after {test_timeout}s\n{e.stdout or ''}"
+                            passed = False
+                        else:
+                            passed = run.returncode == 0
+                            last_output = run.stdout or ""
+                            logger.debug(
+                                "test %s %s (rc=%d, attempt %d/%d)",
+                                test_name,
+                                "PASSED" if passed else "FAILED",
+                                run.returncode,
+                                attempt,
+                                retry,
+                            )
+                    if passed:
+                        if attempt > 1:
+                            logger.info("test %s passed on attempt %d/%d in %s", test_name, attempt, retry, challenge_path)
+                        break
+
+                    if retry > 1:
+                        failed_attempt_outputs.append(f"=== attempt {attempt}/{retry} ===\n{last_output}")
+                    else:
+                        failed_attempt_outputs.append(last_output)
+
+                if not passed:
+                    results.append((test_name, False, "\n".join(failed_attempt_outputs) if retry > 1 else last_output))
+                    continue
+
+                results.append((test_name, True, last_output))
             return {"path": challenge_path, "tests": results}
         except (FileNotFoundError, RuntimeError, subprocess.CalledProcessError) as error:
             logger.error("test setup failed for %s: %s", challenge_path, error)

--- a/tools/pwnshop/src/pwnshop/commands/test.py
+++ b/tools/pwnshop/src/pwnshop/commands/test.py
@@ -91,9 +91,7 @@ def test_command(targets, modified_since, jobs, require_tests, test_timeout, log
                 last_output = ""
                 failed_attempt_outputs = []
                 for attempt in range(1, attempts + 1):
-                    logger.debug(
-                        "running test %s in %s (attempt %d/%d)", test_name, challenge_path, attempt, attempts
-                    )
+                    logger.debug("running test %s in %s (attempt %d/%d)", test_name, challenge_path, attempt, attempts)
                     with lib.run_challenge(challenge_path, image_id, volumes=[test]) as (container, _):
                         try:
                             run = subprocess.run(


### PR DESCRIPTION
This PR makes `pwnshop test` more resilient to flaky challenge behavior by adding per-test `--attempts` and renaming `--test-timeout` to `--timeout`, so tests can pass on a successful retry while still failing after all attempts are exhausted. It also updates CI to validate `dojo.yml` in a dedicated step and run tests with explicit `--attempts 5` and `--timeout 120` settings for more stable, readable test execution.
