### PR TITLE
ci: remove flakehub-cache-action dependency

### DIFF
--- a/.github/actions/setup-nix/action.yml
+++ b/.github/actions/setup-nix/action.yml
@@ -7,4 +7,3 @@ runs:
       with:
         extra-conf: |
           accept-flake-config = true
-    - uses: DeterminateSystems/flakehub-cache-action@v3.15.2


### PR DESCRIPTION
I honestly think this flakehub cache thing makes things slower (especially because it always tries to update the cache at the end, which can take minutes). Almost everything is on the global nix cache, and we already store our custom stuff in r2, so the only potential benefit is PRs where we're iteratively making changes to nix-stored things, which is rare.