### PR TITLE
ci: set kernel core_pattern to core

### DIFF
--- a/.github/actions/setup-challenge-runtime/action.yml
+++ b/.github/actions/setup-challenge-runtime/action.yml
@@ -9,6 +9,7 @@ runs:
         echo "::group::Disk usage"
         df -h
         echo "::endgroup::"
+        sudo sysctl -w kernel.core_pattern=core
         sudo mkdir -p /mnt/pwn.college
         sudo ln -s /mnt/pwn.college /var/lib/pwn.college
         nix develop -c bash -lc 'echo DOCKER_HOST=$DOCKER_HOST'


### PR DESCRIPTION
Sets `kernel.core_pattern=core` during challenge runtime setup so crash-heavy tests do not route through the host crash handler on GitHub runners.

The fork server challenge, fork foolery, which needs to crash thousands of times, seemed to be OOMing because of apport (the default handler).