### PR TITLE
linux-lunarium: fix description for script-pipe

### DIFF
--- a/challenges/linux-luminarium/chaining/script-pipe/DESCRIPTION.md
+++ b/challenges/linux-luminarium/chaining/script-pipe/DESCRIPTION.md
@@ -5,20 +5,19 @@ There are a few ways to do this, and we'll explore a simple one here: redirectin
 
 As far as the shell is concerned, your script is just another command.
 That means you can redirect its input and output just like you did for commands in the [Piping](/linux-luminarium/piping) module!
-For example, you can write it to a file:
+
+For example, you can pipe the output of your script into another command:
 
 ```console
 hacker@dojo:~$ cat script.sh
+#!/bin/bash
 echo PWN
 echo COLLEGE
-hacker@dojo:~$ bash script.sh > output
-hacker@dojo:~$ cat output
+hacker@dojo:~$ ./script.sh | cat
 PWN
 COLLEGE
-hacker@dojo:~$
 ```
 
 All of the various redirection methods work: `>` for stdout, `2>` for stderr, `<` for stdin, `>>` and `2>>` for append-mode redirection, `>&` for redirecting to other file descriptors, and `|` for piping to another command.
 
-In this level, we will practice piping (`|`) from your script to another program.
-Like before, you need to create a script that calls the `/challenge/pwn` command followed by the `/challenge/college` command, and pipe the output of the script into a single invocation of the `/challenge/solve` command!
+In this level, we will practice piping (`|`) the output from your executable script into another program. Specifically, create an executable script that calls `/challenge/pwn` followed by `/challenge/college`, and pipe the output of your script into a single invocation of `/challenge/solve`!


### PR DESCRIPTION
The challenge will not complete successfully if you run it as shown in the example.

```bash
bash script.sh | /challenge/solve 
It looks like you are not piping this script out to /challenge/solve! Remember 
to pipe the output of your script into /challenge/solve using '|'.
The data piped from /challenge/pwn did not match what I expected. I 
re-randomize the data every time you input a new line to the shell, so you must 
get it right in one shot! Make sure to pipe the output from your script to 
/challenge/solve.
```
The challenge actually wants to get his input from an executable script like this:

```bash
.script.sh | /challenge/solve
```

I suggest moving "Redirect Script Output" after the "Executable Shell Scripts" challenge on the website, but I don't know if this is done in this repository or somewhere else.
This would make sense because the user needs the knowledge to find a solution for this challenge.
I also suggest using the updated description from this pull request for more precision.

<img width="1206" height="168" alt="image" src="https://github.com/user-attachments/assets/b569b614-acbb-46b0-84e2-db3cd3b9b1fc" />
