### PR TITLE
computer-101: Add new challenge for passing parameters in GDB

### DIFF
--- a/challenges/computing-101/control-flow/cmp-reverse/DESCRIPTION.md
+++ b/challenges/computing-101/control-flow/cmp-reverse/DESCRIPTION.md
@@ -10,7 +10,7 @@ How do you solve this?
 You must read the disassembly of the program, analyze the `cmp` instructions, understand the password that the program needs, then run it with the correct argument.
 
 You already have the tools for this!
-From the [Software Introspection](/computing-101/software-introspection) module, remember: `objdump -d -M intel /challenge/reverse-me` disassembles the binary and shows its assembly instructions.
+From the [Software Introspection](/computing-101/introspection) module, remember: `objdump -d -M intel /challenge/reverse-me` disassembles the binary and shows its assembly instructions.
 You'll see familiar `cmp` instructions similar to those you wrote in the last challenge, but instead of the familiar `''`-quoted characters, the compared-against values will be written as hex.
 The immediate values in those comparisons _are_ the password characters, encoded as hexadecimal ASCII values.
 

--- a/challenges/computing-101/control-flow/cmp-reverse/DESCRIPTION.md
+++ b/challenges/computing-101/control-flow/cmp-reverse/DESCRIPTION.md
@@ -10,7 +10,7 @@ How do you solve this?
 You must read the disassembly of the program, analyze the `cmp` instructions, understand the password that the program needs, then run it with the correct argument.
 
 You already have the tools for this!
-From the [Software Introspection](/computing-101/introspection) module, remember: `objdump -d -M intel /challenge/reverse-me` disassembles the binary and shows its assembly instructions.
+From the [Software Introspection](/computing-101/introspecting) module, remember: `objdump -d -M intel /challenge/reverse-me` disassembles the binary and shows its assembly instructions.
 You'll see familiar `cmp` instructions similar to those you wrote in the last challenge, but instead of the familiar `''`-quoted characters, the compared-against values will be written as hex.
 The immediate values in those comparisons _are_ the password characters, encoded as hexadecimal ASCII values.
 

--- a/challenges/computing-101/control-flow/switch/DESCRIPTION.md
+++ b/challenges/computing-101/control-flow/switch/DESCRIPTION.md
@@ -27,6 +27,9 @@ In this way, the program implements conditional logic _without any conditional c
 This challenge (at `/challenge/reverse-me`) has 256 possible cases, with only one of them (corresponding to an alphanumeric character) being different than the others.
 Look at the jump table (you'll have to look at a lot of entries...), look at the program to understand how to influence the index, and get the flag!
 
+You must pass an argument to the program. If you don't, it will crash with a segmentation fault.
+From the [Software Introspection](/computing-101/introspection) module, remember: you practiced passing arguments in gdb. To pass an argument here, either launch with `gdb --args /challenge/reverse-me YOUR_INPUT`, or launch gdb first and run `set args YOUR_INPUT` before `starti`.
+
 ----
 **NOTE:**
 Though you should look at the disassembly using `objdump -d -M intel /challenge/reverse-me`, objdump will try to interpret the jump table data as assembly instructions, which will result in garbage.

--- a/challenges/computing-101/control-flow/switch/DESCRIPTION.md
+++ b/challenges/computing-101/control-flow/switch/DESCRIPTION.md
@@ -28,7 +28,7 @@ This challenge (at `/challenge/reverse-me`) has 256 possible cases, with only on
 Look at the jump table (you'll have to look at a lot of entries...), look at the program to understand how to influence the index, and get the flag!
 
 You must pass an argument to the program. If you don't, it will crash with a segmentation fault.
-From the [Software Introspection](/computing-101/introspection) module, remember: you practiced passing arguments in gdb. To pass an argument here, either launch with `gdb --args /challenge/reverse-me YOUR_INPUT`, or launch gdb first and run `set args YOUR_INPUT` before `starti`.
+From the [Software Introspection](/computing-101/introspecting) module, remember: you practiced passing arguments in gdb. To pass an argument here, either launch with `gdb --args /challenge/reverse-me YOUR_INPUT`, or launch gdb first and run `set args YOUR_INPUT` before `starti`.
 
 ----
 **NOTE:**

--- a/challenges/computing-101/introspecting/gdb-args/DESCRIPTION.md
+++ b/challenges/computing-101/introspecting/gdb-args/DESCRIPTION.md
@@ -14,7 +14,7 @@ hacker@dojo:~$ /challenge/debug-me arg1 arg2 arg3
 ```
 
 In this level, using `set args` **is mandatory**.
-If you start the program in gdb without at least two arguments, the program exits before it reveals the secret.
+The program requires **exactly two arguments**. If you provide any other number of arguments, the program exits before it reveals the secret.
 
 Also, passing arguments directly outside gdb will not help you solve this level!
 For example, running:
@@ -35,7 +35,7 @@ When the arguments are set correctly, the secret will be loaded into the `rdi` r
 Go and do that!
 
 1. Launch gdb on `/challenge/debug-me`
-2. Run `set args <arg1> <arg2>` (arg1 and arg2 can be anything)
+2. Run `set args <arg1> <arg2>` (exactly 2 arguments), arg1 and arg2 can be anything
 3. Start the program (`starti`), then continue (`continue`)
 4. Read the secret with `print $rdi`
 5. Submit with `/challenge/submit-number`

--- a/challenges/computing-101/introspecting/gdb-args/DESCRIPTION.md
+++ b/challenges/computing-101/introspecting/gdb-args/DESCRIPTION.md
@@ -1,0 +1,47 @@
+In the previous levels, arguments were already configured for you.
+Now it's your turn to set them yourself.
+
+GDB lets you configure command-line arguments with `set args`. This lets you _simulate_ running the program with different arguments without actually relaunching GDB.
+
+```gdb
+(gdb) set args arg1 arg2 arg3
+```
+
+After this, when you start the program (e.g., via `starti`), it will run as if you launched:
+
+```console
+hacker@dojo:~$ /challenge/debug-me arg1 arg2 arg3
+```
+
+In this level, using `set args` **is mandatory**.
+If you start the program in gdb without at least two arguments, the program exits before it reveals the secret.
+
+Also, passing arguments directly outside gdb will not help you solve this level!
+For example, running:
+
+```console
+hacker@dojo:~$ /challenge/debug-me hello world
+Trace/breakpoint trap
+```
+
+Will not work, and this is intentional. The program stops at `int3` (a breakpoint) before it can reveal the secret, and this is to force you to use gdb and set the arguments there.
+
+When the arguments are set correctly, the secret will be loaded into the `rdi` register. At that point, you can recover it with:
+
+```gdb
+(gdb) print $rdi
+```
+
+Go and do that!
+
+1. Launch gdb on `/challenge/debug-me`
+2. Run `set args <arg1> <arg2>` (arg1 and arg2 can be anything)
+3. Start the program (`starti`), then continue (`continue`)
+4. Read the secret with `print $rdi`
+5. Submit with `/challenge/submit-number`
+
+----
+
+**NOTE:**
+This level expects you to use `set args` from inside gdb.
+Other forms exist (such as launching with `gdb --args ...`, or from inside gdb using `run arg1 arg2`), but they are out of scope for this level.

--- a/challenges/computing-101/introspecting/gdb-args/challenge/.gdb
+++ b/challenges/computing-101/introspecting/gdb-args/challenge/.gdb
@@ -1,0 +1,13 @@
+set disassembly-flavor intel
+set logging redirect on
+set logging file /dev/null
+set logging on
+set confirm off
+set height 0
+
+define hook-stop
+  set logging off
+  printf "\n"
+  disas
+  printf "\n"
+end

--- a/challenges/computing-101/introspecting/gdb-args/challenge/.gdb
+++ b/challenges/computing-101/introspecting/gdb-args/challenge/.gdb
@@ -11,3 +11,9 @@ define hook-stop
   disas
   printf "\n"
 end
+
+break int3_loc
+commands
+silent
+python gdb.execute("set $rdi = " + __import__("subprocess").check_output(["/challenge/.read-secret"]).decode().strip())
+end

--- a/challenges/computing-101/introspecting/gdb-args/challenge/.init
+++ b/challenges/computing-101/introspecting/gdb-args/challenge/.init
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-NUM=$((RANDOM % 65536))
+NUM=$((RANDOM % 512))
 echo $NUM > /challenge/.correct
 chmod 600 /challenge/.correct
 

--- a/challenges/computing-101/introspecting/gdb-args/challenge/.init
+++ b/challenges/computing-101/introspecting/gdb-args/challenge/.init
@@ -4,7 +4,8 @@ NUM=$((RANDOM % 65536))
 echo $NUM > /challenge/.correct
 chmod 600 /challenge/.correct
 
-# Only reveals the secret when two args are passed
+# NUM is injected at runtime via /challenge/.read-secret, called from a
+# breakpoint command in .gdb that targets the int3_loc label below.
 ASM=$(mktemp).o
 as -o $ASM <<EOF
 .intel_syntax noprefix
@@ -15,7 +16,8 @@ main:
     cmp rdi, 3
     jne no_break
 
-    mov rdi, $NUM
+.global int3_loc
+int3_loc:
     int3
 
     mov rdi, 0

--- a/challenges/computing-101/introspecting/gdb-args/challenge/.init
+++ b/challenges/computing-101/introspecting/gdb-args/challenge/.init
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+NUM=$((RANDOM % 65536))
+echo $NUM > /challenge/.correct
+chmod 600 /challenge/.correct
+
+# Only reveals the secret when two args are passed
+ASM=$(mktemp).o
+as -o $ASM <<EOF
+.intel_syntax noprefix
+
+.global main
+main:
+    pop rdi
+    cmp rdi, 3
+    jne no_break
+
+    mov rdi, $NUM
+    int3
+
+    mov rdi, 0
+    mov rax, 60
+    syscall
+
+no_break:
+    mov rdi, 0
+    mov rax, 60
+    syscall
+EOF
+
+ld -o /challenge/debug-me $ASM 2>/tmp/.init.log
+rm $ASM

--- a/challenges/computing-101/introspecting/gdb-args/challenge/.read-secret
+++ b/challenges/computing-101/introspecting/gdb-args/challenge/.read-secret
@@ -6,7 +6,7 @@
 #   - and where the tracee was launched with at least 2 user-supplied args
 #     (i.e. the user actually ran `set args`).
 
-export PATH=/challenge/bin:/bin:/usr/bin:/usr/local/bin
+export PATH=/usr/bin:/bin
 set -euo pipefail
 
 parent_comm=$(cat /proc/$PPID/comm 2>/dev/null || true)

--- a/challenges/computing-101/introspecting/gdb-args/challenge/.read-secret
+++ b/challenges/computing-101/introspecting/gdb-args/challenge/.read-secret
@@ -1,0 +1,31 @@
+#!/usr/bin/exec-suid --real -- /bin/bash -p
+
+# SUID helper that hands NUM only to a real gdb session that:
+#   - is our direct parent process (its comm is "gdb"),
+#   - is currently tracing /challenge/debug-me,
+#   - and where the tracee was launched with at least 2 user-supplied args
+#     (i.e. the user actually ran `set args`).
+
+set -u
+
+parent_comm=$(cat /proc/$PPID/comm 2>/dev/null || true)
+[[ "$parent_comm" == "gdb" ]] || exit 1
+
+tracee_pid=""
+for status_file in /proc/[0-9]*/status; do
+    if grep -qE "^TracerPid:[[:space:]]+$PPID$" "$status_file" 2>/dev/null; then
+        tracee_pid=${status_file#/proc/}
+        tracee_pid=${tracee_pid%/status}
+        break
+    fi
+done
+[[ -n "$tracee_pid" ]] || exit 1
+
+tracee_exe=$(readlink "/proc/$tracee_pid/exe" 2>/dev/null || true)
+[[ "$tracee_exe" == "/challenge/debug-me" ]] || exit 1
+
+# /proc/<pid>/cmdline is NUL-separated, one NUL per argv entry.
+argv_nul_count=$(tr -cd '\0' < "/proc/$tracee_pid/cmdline" 2>/dev/null | wc -c)
+[[ "$argv_nul_count" -ge 3 ]] || exit 1
+
+cat /challenge/.correct

--- a/challenges/computing-101/introspecting/gdb-args/challenge/.read-secret
+++ b/challenges/computing-101/introspecting/gdb-args/challenge/.read-secret
@@ -6,7 +6,8 @@
 #   - and where the tracee was launched with at least 2 user-supplied args
 #     (i.e. the user actually ran `set args`).
 
-set -u
+export PATH=/challenge/bin:/bin:/usr/bin:/usr/local/bin
+set -euo pipefail
 
 parent_comm=$(cat /proc/$PPID/comm 2>/dev/null || true)
 [[ "$parent_comm" == "gdb" ]] || exit 1

--- a/challenges/computing-101/introspecting/gdb-args/challenge/Dockerfile.j2
+++ b/challenges/computing-101/introspecting/gdb-args/challenge/Dockerfile.j2
@@ -1,0 +1,1 @@
+{% include "../../../common/Dockerfile.j2" %}

--- a/challenges/computing-101/introspecting/gdb-args/challenge/Dockerfile.j2
+++ b/challenges/computing-101/introspecting/gdb-args/challenge/Dockerfile.j2
@@ -1,1 +1,7 @@
-{% include "../../../common/Dockerfile.j2" %}
+{%- extends "../../../common/Dockerfile.j2" %}
+
+{%- block after_setup %}
+{{- super() -}}
+# Set SUID so it can read /challenge/.correct and inject it to gdb
+RUN chmod 4755 /challenge/.read-secret
+{%- endblock %}

--- a/challenges/computing-101/introspecting/gdb-args/challenge/bin/gdb
+++ b/challenges/computing-101/introspecting/gdb-args/challenge/bin/gdb
@@ -1,0 +1,21 @@
+#!/bin/bash -e
+
+if [ "$#" -eq 0 ]
+then
+	fold -s <<<"You called gdb without any arguments. Please provide it the filename!"
+	exit 1
+fi
+
+if [ "$#" -ne 1 ]
+then
+	fold -s <<<"You are trying to pass multiple options to gdb (possibly --set-args). Let's keep it simple for this level: just debug the /challenge/debug-me file!"
+	exit 1
+fi
+
+if [ "$(realpath "$1")" != "/challenge/debug-me" ]
+then
+	fold -s <<<"It looks like you are trying to debug a file other than /challenge/debug-me. Make sure to debug the right file!"
+	exit 1
+fi
+
+exec /usr/bin/gdb -x /challenge/.gdb "$@"

--- a/challenges/computing-101/introspecting/gdb-args/challenge/bin/objdump
+++ b/challenges/computing-101/introspecting/gdb-args/challenge/bin/objdump
@@ -1,0 +1,3 @@
+#!/bin/bash -e
+
+echo "We've disabled objdump for this level --- use gdb!"

--- a/challenges/computing-101/introspecting/gdb-args/challenge/submit-number.j2
+++ b/challenges/computing-101/introspecting/gdb-args/challenge/submit-number.j2
@@ -1,0 +1,1 @@
+{% include "../../../common/submit-number" %}

--- a/challenges/computing-101/introspecting/gdb-args/tests_public/test_solve.sh
+++ b/challenges/computing-101/introspecting/gdb-args/tests_public/test_solve.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+GDB=$(command -v gdb)
+if [[ -z "$GDB" ]]; then
+  echo "FAIL: gdb not found on PATH"
+  exit 1
+fi
+
 # Running outside gdb should still trap on int3
 OUTSIDE_OUTPUT=$(/challenge/debug-me hello world 2>&1)
 OUTSIDE_STATUS=$?
@@ -17,7 +23,7 @@ if [[ "$OUTSIDE_STATUS" -ne 133 ]] && ! echo "$OUTSIDE_OUTPUT" | grep -Eiq "trac
 fi
 
 # First run without set args: should not hit SIGTRAP/int3
-NO_ARGS_OUTPUT=$(/usr/bin/gdb -q -nx -batch \
+NO_ARGS_OUTPUT=$("$GDB" -q -nx -batch \
   -x /challenge/.gdb \
   -ex "starti" \
   -ex "continue" \
@@ -29,7 +35,7 @@ if echo "$NO_ARGS_OUTPUT" | grep -q "SIGTRAP"; then
 fi
 
 # Now solve the intended way: set args, continue to int3, read rdi
-WITH_ARGS_OUTPUT=$(/usr/bin/gdb -q -nx -batch \
+WITH_ARGS_OUTPUT=$("$GDB" -q -nx -batch \
   -x /challenge/.gdb \
   -ex "set args test1 test2" \
   -ex "starti" \

--- a/challenges/computing-101/introspecting/gdb-args/tests_public/test_solve.sh
+++ b/challenges/computing-101/introspecting/gdb-args/tests_public/test_solve.sh
@@ -44,6 +44,7 @@ if echo "$NO_ARGS_OUTPUT" | grep -q "SIGTRAP"; then
   exit 1
 fi
 
+
 # Now solve the intended way: set args, continue to int3, read rdi
 WITH_ARGS_OUTPUT=$("$GDB" -q -nx -batch \
   -x /challenge/.gdb \
@@ -51,7 +52,7 @@ WITH_ARGS_OUTPUT=$("$GDB" -q -nx -batch \
   -ex "starti" \
   -ex "continue" \
   -ex "print/d \$rdi" \
-  /challenge/debug-me 2>/dev/null || true)
+  /challenge/debug-me 2>&1 || true)
 
 CALCULATED=$(echo "$WITH_ARGS_OUTPUT" | sed -n 's/^\$[0-9][0-9]* = //p' | tail -n 1)
 
@@ -62,6 +63,10 @@ fi
 
 if ! /challenge/submit-number "$CALCULATED" >/dev/null 2>&1; then
   echo "FAIL: Retrieved value was not accepted by submit-number"
+  echo "--- gdb output ---"
+  echo "$WITH_ARGS_OUTPUT"
+  echo "--- end gdb output ---"
+  ls -la /challenge/
   exit 1
 fi
 

--- a/challenges/computing-101/introspecting/gdb-args/tests_public/test_solve.sh
+++ b/challenges/computing-101/introspecting/gdb-args/tests_public/test_solve.sh
@@ -3,15 +3,15 @@
 # Prefer the system gdb directly so the /challenge/bin/gdb wrapper (which
 # rejects multi-arg invocations) does not interfere with testing
 GDB=/usr/bin/gdb
-[[ -x "$GDB" ]] || GDB=$(command -v gdb)
-if [[ -z "$GDB" ]]; then
+[[ -x "$GDB" ]] || GDB=$(PATH=/usr/bin:/bin command -v gdb 2>/dev/null || true)
+if [[ -z "$GDB" || ! -x "$GDB" || "$GDB" == "/challenge/bin/gdb" ]]; then
   echo "FAIL: gdb not found"
   exit 1
 fi
 
 OBJDUMP=/usr/bin/objdump
-[[ -x "$OBJDUMP" ]] || OBJDUMP=$(command -v objdump)
-if [[ -z "$OBJDUMP" ]]; then
+[[ -x "$OBJDUMP" ]] || OBJDUMP=$(PATH=/usr/bin:/bin command -v objdump 2>/dev/null || true)
+if [[ -z "$OBJDUMP" || ! -x "$OBJDUMP" || "$OBJDUMP" == "/challenge/bin/objdump" ]]; then
   echo "FAIL: objdump not found"
   exit 1
 fi

--- a/challenges/computing-101/introspecting/gdb-args/tests_public/test_solve.sh
+++ b/challenges/computing-101/introspecting/gdb-args/tests_public/test_solve.sh
@@ -1,8 +1,18 @@
 #!/bin/bash
 
-GDB=$(command -v gdb)
+# Prefer the system gdb directly so the /challenge/bin/gdb wrapper (which
+# rejects multi-arg invocations) does not interfere with testing
+GDB=/usr/bin/gdb
+[[ -x "$GDB" ]] || GDB=$(command -v gdb)
 if [[ -z "$GDB" ]]; then
-  echo "FAIL: gdb not found on PATH"
+  echo "FAIL: gdb not found"
+  exit 1
+fi
+
+OBJDUMP=/usr/bin/objdump
+[[ -x "$OBJDUMP" ]] || OBJDUMP=$(command -v objdump)
+if [[ -z "$OBJDUMP" ]]; then
+  echo "FAIL: objdump not found"
   exit 1
 fi
 
@@ -50,10 +60,25 @@ if [[ -z "$CALCULATED" ]]; then
   exit 1
 fi
 
-if /challenge/submit-number "$CALCULATED" >/dev/null 2>&1; then
-  echo "PASS"
-  exit 0
-else
+if ! /challenge/submit-number "$CALCULATED" >/dev/null 2>&1; then
   echo "FAIL: Retrieved value was not accepted by submit-number"
   exit 1
 fi
+
+# Skipped for NUM=0 since the binary's exit-path `mov rdi, 0x0` would false-positive.
+if [[ "$CALCULATED" -ne 0 ]]; then
+  NUM_HEX=$(printf '0x%x' "$CALCULATED")
+  if "$OBJDUMP" -d -M intel /challenge/debug-me 2>/dev/null | grep -qE "mov[[:space:]]+rdi.*(${NUM_HEX}|${CALCULATED})"; then
+    echo "FAIL: NUM is statically visible via objdump on /challenge/debug-me"
+    exit 1
+  fi
+fi
+
+# The SUID helper must refuse callers whose parent is not gdb
+if /challenge/.read-secret >/dev/null 2>&1; then
+  echo "FAIL: /challenge/.read-secret leaked NUM to a non-gdb caller"
+  exit 1
+fi
+
+echo "PASS"
+exit 0

--- a/challenges/computing-101/introspecting/gdb-args/tests_public/test_solve.sh
+++ b/challenges/computing-101/introspecting/gdb-args/tests_public/test_solve.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+# Running outside gdb should still trap on int3
+OUTSIDE_OUTPUT=$(/challenge/debug-me hello world 2>&1)
+OUTSIDE_STATUS=$?
+
+set -e
+
+if [[ "$OUTSIDE_STATUS" -eq 0 ]]; then
+  echo "FAIL: Direct launch unexpectedly succeeded"
+  exit 1
+fi
+
+if [[ "$OUTSIDE_STATUS" -ne 133 ]] && ! echo "$OUTSIDE_OUTPUT" | grep -Eiq "trace/breakpoint trap|breakpoint trap|SIGTRAP"; then
+  echo "FAIL: Direct launch did not appear to trap as expected"
+  exit 1
+fi
+
+# First run without set args: should not hit SIGTRAP/int3
+NO_ARGS_OUTPUT=$(/usr/bin/gdb -q -nx -batch \
+  -x /challenge/.gdb \
+  -ex "starti" \
+  -ex "continue" \
+  /challenge/debug-me 2>/dev/null || true)
+
+if echo "$NO_ARGS_OUTPUT" | grep -q "SIGTRAP"; then
+  echo "FAIL: Program hit breakpoint without arguments"
+  exit 1
+fi
+
+# Now solve the intended way: set args, continue to int3, read rdi
+WITH_ARGS_OUTPUT=$(/usr/bin/gdb -q -nx -batch \
+  -x /challenge/.gdb \
+  -ex "set args test1 test2" \
+  -ex "starti" \
+  -ex "continue" \
+  -ex "print/d \$rdi" \
+  /challenge/debug-me 2>/dev/null || true)
+
+CALCULATED=$(echo "$WITH_ARGS_OUTPUT" | sed -n 's/^\$[0-9][0-9]* = //p' | tail -n 1)
+
+if [[ -z "$CALCULATED" ]]; then
+  echo "FAIL: Could not read rdi after breakpoint"
+  exit 1
+fi
+
+if /challenge/submit-number "$CALCULATED" >/dev/null 2>&1; then
+  echo "PASS"
+  exit 0
+else
+  echo "FAIL: Retrieved value was not accepted by submit-number"
+  exit 1
+fi

--- a/challenges/computing-101/introspecting/module.yml
+++ b/challenges/computing-101/introspecting/module.yml
@@ -98,5 +98,8 @@ resources:
   id: gdb-examine-argv1
   name: "Examining Stack Pointers"
 - type: challenge
+  id: gdb-args
+  name: "Passing Parameters to Programs"
+- type: challenge
   id: gdb-int3
   name: "Cooperative Debugging"

--- a/challenges/computing-101/introspecting/module.yml
+++ b/challenges/computing-101/introspecting/module.yml
@@ -98,6 +98,9 @@ resources:
   id: gdb-examine-argv1
   name: "Examining Stack Pointers"
 - type: challenge
+  id: gdb-args
+  name: "Passing Parameters to Programs"
+- type: challenge
   id: gdb-int3
   name: "Cooperative Debugging"
 - type: challenge


### PR DESCRIPTION
As I was doing the control-flow challenges, I got stuck at the "Conditionals Without Conditionals" challenge as I kept getting segmentation faults 🙃

I thought there was something wrong with the challenge, so I wrote a for-loop to brute-force the flag and check whether the issue was my approach or the code itself. Turns out it was the former... I just didn't know I had to provide an argument.

This MR includes three things:

- A fix to the "Reverse the Password" challenge description
- A new challenge that teaches how to set arguments in gdb
- A minor change to the "Conditionals Without Conditionals" challenge to link to this new one, so this "confusion" doesn't happen again for anyone else

Tests are public under test_public as I don't have access to the module's key

I've run the tests inside the nix challenge shell, and all passed:

<img width="747" height="101" alt="image" src="https://github.com/user-attachments/assets/8cf0c38c-c9be-4293-8117-863d35d3e18b" />