### PR TITLE
Fix argument pointer value in DESCRIPTION.md

### DIFF
--- a/challenges/computing-101/the-stack/mem-argv1/DESCRIPTION.md
+++ b/challenges/computing-101/the-stack/mem-argv1/DESCRIPTION.md
@@ -42,7 +42,7 @@ For example, if your program is run as `/tmp/your-program Hi`:
 To get the actual argument data, you need to dereference twice: once to get the pointer from the stack, and once to follow it to the data.
 
 ```assembly
-mov rdi, [rsp+16]   # load the first argument pointer (e.g., 1234000) from the stack
+mov rdi, [rsp+16]   # load the first argument pointer (e.g., 1234560) from the stack
 mov rdi, [rdi]      # follow the pointer to read the actual data (e.g., "Hi")
 ```
 


### PR DESCRIPTION
Correct the example argument pointer in assembly code.