### PR TITLE
ci: parameterize challenge registry publishing

### DIFF
--- a/.github/actions/determine-modified-challenges/action.yml
+++ b/.github/actions/determine-modified-challenges/action.yml
@@ -1,11 +1,16 @@
 name: Determine modified challenges
-description: Determine modified challenges and group them by top-level directory.
+description: Determine modified challenges, apply an optional glob filter, and group them for downstream jobs.
+inputs:
+  challenge_filter:
+    description: Challenge path glob under challenges/.
+    required: false
+    default: ""
 outputs:
   modified_since_ref:
     description: Base ref challenges have been modified since.
     value: ${{ steps.resolve-ref.outputs.ref }}
   challenges:
-    description: Top-level challenge groups.
+    description: Filtered top-level challenge groups.
     value: ${{ steps.resolve-challenges.outputs.challenges }}
 runs:
   using: composite
@@ -47,26 +52,30 @@ runs:
     - uses: actions/github-script@v8
       id: resolve-challenges
       env:
+        CHALLENGE_FILTER: ${{ inputs.challenge_filter || vars.CHALLENGE_FILTER || '**' }}
         MODIFIED_SINCE: ${{ steps.resolve-ref.outputs.ref }}
       with:
         script: |
-          const { execFileSync } = require("child_process");
+          const childProcess = require("child_process");
+          const path = require("path");
           const ref = process.env.MODIFIED_SINCE || "";
-          const output = execFileSync("./pwnshop", ["list", "./challenges", `--modified-since=${ref}`], {
+          const challengeFilter = process.env.CHALLENGE_FILTER.trim();
+          const output = childProcess.execFileSync("./pwnshop", ["list", "./challenges", `--modified-since=${ref}`], {
             stdio: ["ignore", "pipe", "inherit"],
           })
             .toString()
             .trim();
+          const listedChallenges = output.split("\n").map((line) => line.trim()).filter(Boolean);
+          const groupChallenge = (challenge) => {
+            const parts = challenge.split("/");
+            if (parts[0] === "legacy") return `legacy/${parts[1]}`;
+            return challenge;
+          };
           const challenges = Array.from(
             new Set(
-              output
-                .split("\n")
-                .map((line) => {
-                  const parts = line.trim().split("/");
-                  if (parts[0] === "legacy") return `legacy/${parts[1]}`;
-                  return parts[0];
-                })
-                .filter(Boolean),
+              listedChallenges
+                .filter((challenge) => path.matchesGlob(challenge, challengeFilter))
+                .map(groupChallenge),
             ),
           ).sort();
           core.setOutput("challenges", JSON.stringify(challenges));

--- a/.github/actions/determine-modified-challenges/action.yml
+++ b/.github/actions/determine-modified-challenges/action.yml
@@ -52,7 +52,7 @@ runs:
     - uses: actions/github-script@v8
       id: resolve-challenges
       env:
-        CHALLENGE_FILTER: ${{ inputs.challenge_filter || vars.CHALLENGE_FILTER || '**' }}
+        CHALLENGE_FILTER: ${{ inputs.challenge_filter || '**' }}
         MODIFIED_SINCE: ${{ steps.resolve-ref.outputs.ref }}
       with:
         script: |

--- a/.github/actions/determine-modified-challenges/action.yml
+++ b/.github/actions/determine-modified-challenges/action.yml
@@ -4,7 +4,7 @@ inputs:
   challenge_filter:
     description: Challenge path glob under challenges/.
     required: false
-    default: ""
+    default: "**"
 outputs:
   modified_since_ref:
     description: Base ref challenges have been modified since.
@@ -52,14 +52,14 @@ runs:
     - uses: actions/github-script@v8
       id: resolve-challenges
       env:
-        CHALLENGE_FILTER: ${{ inputs.challenge_filter || '**' }}
+        CHALLENGE_FILTER: ${{ inputs.challenge_filter }}
         MODIFIED_SINCE: ${{ steps.resolve-ref.outputs.ref }}
       with:
         script: |
           const childProcess = require("child_process");
           const path = require("path");
           const ref = process.env.MODIFIED_SINCE || "";
-          const challengeFilter = process.env.CHALLENGE_FILTER.trim();
+          const challengeFilter = process.env.CHALLENGE_FILTER.trim() || "**";
           const output = childProcess.execFileSync("./pwnshop", ["list", "./challenges", `--modified-since=${ref}`], {
             stdio: ["ignore", "pipe", "inherit"],
           })

--- a/.github/actions/read-registry-config/action.yml
+++ b/.github/actions/read-registry-config/action.yml
@@ -1,0 +1,40 @@
+name: Read registry config
+description: Read registry bucket and host values from the Worker wrangler.toml.
+inputs:
+  wrangler_toml:
+    description: Path to the Worker wrangler.toml.
+    required: false
+    default: services/registry/wrangler.toml
+outputs:
+  bucket_name:
+    description: R2 bucket name for the registry bucket binding.
+    value: ${{ steps.read-registry-config.outputs.bucket_name }}
+  registry_host:
+    description: Registry hostname from the first Worker route pattern.
+    value: ${{ steps.read-registry-config.outputs.registry_host }}
+runs:
+  using: composite
+  steps:
+    - name: Read registry config
+      id: read-registry-config
+      shell: 'nix develop -c bash -euo pipefail {0}'
+      env:
+        WRANGLER_TOML: ${{ inputs.wrangler_toml }}
+      run: |
+        bucket_name="$(tq -o json -f "$WRANGLER_TOML" r2_buckets | jq -r '.[] | select(.binding == "REGISTRY_BUCKET") | .bucket_name')"
+        registry_host="$(tq -o json -f "$WRANGLER_TOML" routes | jq -r '.[0].pattern')"
+
+        if [ -z "$bucket_name" ] || [ "$bucket_name" = "null" ]; then
+          echo "::error::Could not find REGISTRY_BUCKET bucket_name in $WRANGLER_TOML"
+          exit 1
+        fi
+
+        case "$registry_host" in
+          ""|"null"|*'*'*|*/*|*:*)
+            echo "::error::Registry route pattern must be a bare hostname, got: $registry_host"
+            exit 1
+            ;;
+        esac
+
+        printf 'bucket_name=%s\n' "$bucket_name" >> "$GITHUB_OUTPUT"
+        printf 'registry_host=%s\n' "$registry_host" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/prune-registry.yml
+++ b/.github/workflows/prune-registry.yml
@@ -18,6 +18,9 @@ jobs:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-nix
 
+      - uses: ./.github/actions/read-registry-config
+        id: registry-config
+
       - name: Configure AWS credentials
         shell: 'nix shell nixpkgs#awscli2 --command bash --noprofile --norc -euo pipefail {0}'
         env:
@@ -32,12 +35,15 @@ jobs:
         shell: 'nix shell nixpkgs#awscli2 --command bash --noprofile --norc -euo pipefail {0}'
         env:
           R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+          R2_BUCKET_NAME: ${{ steps.registry-config.outputs.bucket_name }}
         run: |
           aws --endpoint-url "https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com" \
-            s3 ls "s3://challenges-registry" --recursive > "$RUNNER_TEMP/registry-bucket.txt"
+            s3 ls "s3://${R2_BUCKET_NAME}" --recursive > "$RUNNER_TEMP/registry-bucket.txt"
 
       - name: Compute stale set
         shell: python
+        env:
+          REGISTRY_HOST: ${{ steps.registry-config.outputs.registry_host }}
         run: |
           import collections
           import concurrent.futures
@@ -54,7 +60,7 @@ jobs:
 
           def fetch(path):
               req = urllib.request.Request(
-                  f"https://challenges.pwn.college{path}",
+                  f"https://{os.environ['REGISTRY_HOST']}{path}",
                   headers={"User-Agent": "pwncollege-registry-prune/1"},
               )
               with urllib.request.urlopen(req, timeout=30) as resp:
@@ -118,6 +124,7 @@ jobs:
         shell: 'nix shell nixpkgs#awscli2 nixpkgs#jq --command bash --noprofile --norc -euo pipefail {0}'
         env:
           R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+          R2_BUCKET_NAME: ${{ steps.registry-config.outputs.bucket_name }}
         run: |
           shopt -s nullglob
 
@@ -125,7 +132,7 @@ jobs:
 
           for batch in "$RUNNER_TEMP"/stale-batch.*; do
             aws --endpoint-url "https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com" s3api delete-objects \
-              --bucket "challenges-registry" \
+              --bucket "${R2_BUCKET_NAME}" \
               --delete "$(jq -Rn '{Objects:[inputs | {Key:.}]}' < "$batch")" \
               >/dev/null
           done

--- a/.github/workflows/publish-challenges.yml
+++ b/.github/workflows/publish-challenges.yml
@@ -27,7 +27,7 @@ jobs:
       id: determine-modified-challenges
       uses: ./.github/actions/determine-modified-challenges
       with:
-        challenge_filter: ${{ inputs.challenge_filter || vars.CHALLENGE_FILTER }}
+        challenge_filter: ${{ inputs.challenge_filter || vars.CHALLENGE_FILTER || '**' }}
 
 
   publish:

--- a/.github/workflows/publish-challenges.yml
+++ b/.github/workflows/publish-challenges.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches: [ main ]
   workflow_dispatch:
+    inputs:
+      challenge_filter:
+        description: Challenge path glob to publish.
+        required: false
+        default: ""
 
 concurrency:
   group: publish-challenges-${{ github.ref }}
@@ -21,6 +26,8 @@ jobs:
     - name: Determine modified challenges
       id: determine-modified-challenges
       uses: ./.github/actions/determine-modified-challenges
+      with:
+        challenge_filter: ${{ inputs.challenge_filter }}
 
 
   publish:
@@ -51,11 +58,15 @@ jobs:
     - name: Install rclone
       run: sudo apt-get update && sudo apt-get install -y rclone
 
+    - uses: ./.github/actions/read-registry-config
+      id: registry-config
+
     - name: Publish challenges
       shell: 'nix develop -c bash -euo pipefail {0}'
       env:
         CHALLENGES_DIR: challenges/${{ matrix.challenges }}
-        R2_BUCKET_NAME: challenges-registry
+        R2_BUCKET_NAME: ${{ steps.registry-config.outputs.bucket_name }}
+        REGISTRY_SECRET: ${{ secrets.REGISTRY_SECRET }}
         RCLONE_CONFIG_R2_TYPE: s3
         RCLONE_CONFIG_R2_PROVIDER: Cloudflare
         RCLONE_CONFIG_R2_ENDPOINT: https://${{ secrets.R2_ACCOUNT_ID }}.r2.cloudflarestorage.com
@@ -69,6 +80,9 @@ jobs:
         while IFS= read -r line; do
           image_id="${line%% *}"
           challenge_slug="${line#* }"
+          if [ -n "$REGISTRY_SECRET" ]; then
+            challenge_slug="$REGISTRY_SECRET/$challenge_slug"
+          fi
           stack=("$image_id")
           while ((${#stack[@]})); do
             digest="${stack[-1]}"
@@ -96,12 +110,19 @@ jobs:
         echo "::endgroup::"
 
     - name: Update dojo
-      if: ${{ hashFiles(format('challenges/{0}/dojo.yml', matrix.challenges)) != '' }}
+      if: ${{ vars.DOJO_URL != '' && hashFiles(format('challenges/{0}/dojo.yml', matrix.challenges)) != '' }}
       env:
         CHALLENGES_DIR: challenges/${{ matrix.challenges }}
-        DOJO_URL: https://pwn.college
+        DOJO_URL: ${{ vars.DOJO_URL }}
         DOJO_TOKEN: ${{ secrets.DOJO_TOKEN }}
-      run: ./tools/dojo/update-dojo --registry challenges.pwn.college "$CHALLENGES_DIR/dojo.yml"
+        REGISTRY_HOST: ${{ steps.registry-config.outputs.registry_host }}
+        REGISTRY_SECRET: ${{ secrets.REGISTRY_SECRET }}
+      run: |
+        registry="$REGISTRY_HOST"
+        if [ -n "$REGISTRY_SECRET" ]; then
+          registry="$registry/$REGISTRY_SECRET"
+        fi
+        ./tools/dojo/update-dojo --registry "$registry" "$CHALLENGES_DIR/dojo.yml"
 
     - name: Report runtime storage
       if: always()

--- a/.github/workflows/publish-challenges.yml
+++ b/.github/workflows/publish-challenges.yml
@@ -27,7 +27,7 @@ jobs:
       id: determine-modified-challenges
       uses: ./.github/actions/determine-modified-challenges
       with:
-        challenge_filter: ${{ inputs.challenge_filter }}
+        challenge_filter: ${{ inputs.challenge_filter || vars.CHALLENGE_FILTER }}
 
 
   publish:

--- a/.github/workflows/test-challenges.yml
+++ b/.github/workflows/test-challenges.yml
@@ -24,6 +24,8 @@ jobs:
     - name: Determine modified challenges
       id: determine-modified-challenges
       uses: ./.github/actions/determine-modified-challenges
+      with:
+        challenge_filter: ${{ vars.CHALLENGE_FILTER || '**' }}
 
 
   test-challenges:

--- a/flake.nix
+++ b/flake.nix
@@ -66,8 +66,10 @@
               docker
               git
               git-crypt
+              jq
               pwn-challenge-runtime
               pwnshop
+              tomlq
               uv
             ];
             shellHook = ''


### PR DESCRIPTION
This derives the challenge registry bucket and host from `services/registry/wrangler.toml`, uses those values in the publish and prune workflows, makes dojo updates conditional on `DOJO_URL`, and adds optional `REGISTRY_SECRET` and `CHALLENGE_FILTER` support for prefixing registry paths and filtering modified challenge selection.
