### PR TITLE
ci: fix challenge grouping

### DIFF
--- a/.github/actions/determine-modified-challenges/action.yml
+++ b/.github/actions/determine-modified-challenges/action.yml
@@ -69,7 +69,7 @@ runs:
           const groupChallenge = (challenge) => {
             const parts = challenge.split("/");
             if (parts[0] === "legacy") return `legacy/${parts[1]}`;
-            return challenge;
+            return parts[0];
           };
           const challenges = Array.from(
             new Set(


### PR DESCRIPTION
Fixes a regression from #180 where filtered non-legacy challenge paths were returned as full challenge slugs instead of top-level module groups. The filter still applies to the full challenge path, but downstream matrix entries now match the module-level shape expected by test, publish, and dojo update jobs.
