### PR TITLE
computing-101: clarify stack indexing in most-common-byte

### DIFF
--- a/challenges/computing-101/assembly-crash-course/level-23/DESCRIPTION.md
+++ b/challenges/computing-101/assembly-crash-course/level-23/DESCRIPTION.md
@@ -29,24 +29,26 @@ ret
 
 Notice how `rbp` is always used to restore the stack to where it originally was. If we don't restore the stack after use, we will eventually run out. In addition, notice how we subtracted from `rsp`, because the stack grows down. To make the stack have more space, we subtract the space we need. The `ret` and `call` still work the same.
 
-Consider the fact that to assign a value to `list[2]` we subtract 12 bytes (3 dwords). That is because the stack grows down and when we moved `rsp` our stack contains addresses <`rsp`, `rbp`.
+Consider the fact that to assign a value to `list[2]` we subtract 12 bytes (3 dwords). That is because the stack grows down, and after moving `rsp` the allocated stack space runs from `rsp` up to, but not including, `rbp`.
 
 Once again, please make function(s) that implement the following:
 
 ```plaintext
 most_common_byte(src_addr, size):
+  counting_list = rsp - 0x200
+
   i = 0
   while i <= size-1:
     curr_byte = [src_addr + i]
-    [stack_base - curr_byte * 2] += 1
+    [counting_list + curr_byte * 2] += 1
     i += 1
 
   b = 0
   max_freq = 0
   max_freq_byte = 0
   while b <= 0xff:
-    if [stack_base - b * 2] > max_freq:
-      max_freq = [stack_base - b * 2]
+    if [counting_list + b * 2] > max_freq:
+      max_freq = [counting_list + b * 2]
       max_freq_byte = b
     b += 1
 

--- a/challenges/computing-101/assembly-crash-course/level-23/challenge/run.j2
+++ b/challenges/computing-101/assembly-crash-course/level-23/challenge/run.j2
@@ -29,7 +29,7 @@ class ASMLevel30(ASMBase):
 
         self.init_memory = {
             self.LIB_ADDR: self.harness,
-            self.RSP_INIT - 0x100: b"\0" * 0x100,
+            self.RSP_INIT - 0x1000: b"\0" * 0x1000,
             self.init_rdi: bytes(self.test_list),
         }
 
@@ -63,7 +63,7 @@ class ASMLevel30(ASMBase):
         sub rsp, 0x14
         ; assign list[2] = 1337
         mov eax, 1337
-        mov [rbp-0x8], eax
+        mov [rbp-0xc], eax
         ; do more operations on the list ...
         ; restore the allocated space
         mov rsp, rbp
@@ -80,20 +80,26 @@ class ASMLevel30(ASMBase):
 
         The ret and call still works the same.
 
+        Consider the fact that to assign a value to list[2] we subtract 12 bytes (3 dwords).
+        That is because the stack grows down, and after moving rsp the allocated stack space runs
+        from rsp up to, but not including, rbp.
+
         Once, again, please make function(s) that implements the following:
         most_common_byte(src_addr, size):
+          counting_list = rsp - 0x200
+
           i = 0
           while i <= size-1:
             curr_byte = [src_addr + i]
-            [stack_base - curr_byte * 2] += 1
+            [counting_list + curr_byte * 2] += 1
             i += 1
 
           b = 0
           max_freq = 0
           max_freq_byte = 0
           while b <= 0xff:
-            if [stack_base - b * 2] > max_freq:
-              max_freq = [stack_base - b * 2]
+            if [counting_list + b * 2] > max_freq:
+              max_freq = [counting_list + b * 2]
               max_freq_byte = b
             b += 1
 


### PR DESCRIPTION
This updates the `most-common-byte` prompt to avoid an ambiguous stack indexing pattern in the suggested pseudocode.

The old pseudocode used:

```text
[stack_base - curr_byte * 2]
[stack_base - b * 2]
```

For `b = 0`, this points at `[stack_base]`, which can be confused with call-frame data such as the return address rather than local counting-list storage. This caused students following the pseudocode closely to accidentally treat stack metadata as the count for byte `0`.

This PR changes the pseudocode to define a separate `counting_list` base:

```text
counting_list = rsp - 0x200
[counting_list + curr_byte * 2] += 1
```

It also:

- fixes the `list[2]` example offset from `[rbp-0x8]` to `[rbp-0xc]`
- clarifies that allocated stack space runs from `rsp` up to, but not including, `rbp`
- expands the initialized stack area in the runner from `0x100` to `0x1000` so the setup is clearly larger than the counting-list storage

I sanity checked the rendered level with solutions using both explicit stack allocation and the displayed `rsp - 0x200` counting-list base; both passed the 100 randomized checker attempts.
