### PR TITLE
Update DESCRIPTION.md for 32-bit twos complement challenge

### DIFF
--- a/challenges/computing-101/nibbling-on-numbers/twos-complement-dword/DESCRIPTION.md
+++ b/challenges/computing-101/nibbling-on-numbers/twos-complement-dword/DESCRIPTION.md
@@ -1,6 +1,6 @@
 Let's go wider!
 We'll try 4 bytes, 32 bits.
-The maximum unsigned value of this, `11111111 11111111 11111111 11111111`, is `2**32-1`. or `4,294,967,296`.
-The maximum signed value, `01111111 11111111 11111111 11111111`, is `2**31-1`, which is `2,147,483,647`, and the minimum signed value, `10000000 0000000 0000000 0000000 0000000`, is `-2**31`, which is `-2,147,483,647`.
+The maximum unsigned value of this, `11111111 11111111 11111111 11111111`, is `2**32-1`. or `4,294,967,295`.
+The maximum signed value, `01111111 11111111 11111111 11111111`, is `2**31-1`, which is `2,147,483,647`, and the minimum signed value, `10000000 0000000 0000000 0000000 0000000`, is `-2**31`, which is `-2,147,483,648`.
 
 Anyways, go tackle this one and get the flag!


### PR DESCRIPTION
Corrected the values listed in the DESCRIPTION.md file for the twos-complement-dword challenge under Nibbling on Numbers.

Values were off by 1.