### PR TITLE
Address challenge feedback from Discord

### DIFF
--- a/challenges/computing-101/nibbling-on-numbers/mixed-conversions/DESCRIPTION.md
+++ b/challenges/computing-101/nibbling-on-numbers/mixed-conversions/DESCRIPTION.md
@@ -1,3 +1,3 @@
 Of course, the same value can be interpreted/reasoned about in multiple ways.
 We'll explore that here across the four interpretations we've studied (unsigned decimal, signed decimal, hex, and twos-complement binary).
-Get every conversion right, one after another, to earn the flag.
+Work through every conversion to earn the flag.

--- a/challenges/computing-101/nibbling-on-numbers/mixed-conversions/challenge/mixed
+++ b/challenges/computing-101/nibbling-on-numbers/mixed-conversions/challenge/mixed
@@ -9,6 +9,7 @@ with open("/flag") as f:
 
 ENCS = ["sdec", "udec", "hex", "bin"]
 NAME = {"sdec": "signed decimal", "udec": "unsigned decimal", "hex": "hex", "bin": "binary"}
+MAX_ATTEMPTS = 3
 ASK = {
     "sdec": "a signed (two's-complement) decimal number",
     "udec": "an unsigned decimal number",
@@ -50,9 +51,9 @@ def explain_wrong_value(b, src, dst, got):
 def ask_conversion(b, src, dst):
     expected = b - 256 if dst == "sdec" else b
     want_digits = 2 if dst == "hex" else 8 if dst == "bin" else None
-    prompt = f"  TARGET {NAME[dst].upper()} ({ASK[dst]}) > "
+    prompt = f"  CONVERT THE SOURCE VALUE TO {NAME[dst].upper()} ({ASK[dst]}) > "
 
-    for attempt in range(2):
+    for attempt in range(MAX_ATTEMPTS):
         try:
             got, dlen = parse(input(prompt), dst)
         except (EOFError, ValueError):
@@ -66,8 +67,8 @@ def ask_conversion(b, src, dst):
                 print("  Correct!")
                 return
 
-        if attempt == 0:
-            print("  Try this conversion one more time.")
+        if attempt < MAX_ATTEMPTS - 1:
+            print("  Try this conversion again.")
 
     print("  Run me again when you're ready.")
     sys.exit(1)
@@ -84,7 +85,7 @@ print("  - a SIGNED decimal number, -128 to 127 (two's complement)")
 print("  - two HEX digits")
 print("  - eight BINARY bits")
 print(f"I'll show you {len(sources)} bytes. For each, write it in all three of the other forms.")
-print("Get every conversion right in a row, and the flag is yours.\n")
+print("Work through every conversion, and the flag is yours.\n")
 
 for i, src in enumerate(sources, 1):
     b = random.randint(128, 255)  # high bit set, so the signed and unsigned readings differ

--- a/challenges/computing-101/the-stack-revisited/build-frame/DESCRIPTION.md
+++ b/challenges/computing-101/the-stack-revisited/build-frame/DESCRIPTION.md
@@ -10,7 +10,8 @@ You need actual memory, and a function gets its own scratch memory by carving it
 
 Recall that the stack grows *downward*: subtracting from `rsp` moves it to a lower address and leaves the region between the old and new `rsp` free for you to use.
 So `sub rsp, 256` reserves 256 bytes of scratch space; your slots live at `[rsp]` through `[rsp+255]`, indexed by byte value.
-Here, "reserves" means moving `rsp` by convention so your function does not overwrite return or caller data; it does not ask the kernel for fresh memory.
+Note that this doesn't bring any new memory into existence!
+The stack memory was already there, it's just that `rsp` was pointing to one specific place inside it before the `sub`, and after the `sub` it will be pointing a bit further "left", so stack accesses using `rsp` (e.g., `mov [rsp], XYZ`, `mov XYZ, [rsp]`, `pop`) will have more previously-_unused_ memory to play with.
 This reserved region is your function's *stack frame*.
 
 In full, the pattern is reserve, use, then put it back:

--- a/challenges/computing-101/the-stack-revisited/build-frame/DESCRIPTION.md
+++ b/challenges/computing-101/the-stack-revisited/build-frame/DESCRIPTION.md
@@ -10,6 +10,7 @@ You need actual memory, and a function gets its own scratch memory by carving it
 
 Recall that the stack grows *downward*: subtracting from `rsp` moves it to a lower address and leaves the region between the old and new `rsp` free for you to use.
 So `sub rsp, 256` reserves 256 bytes of scratch space; your slots live at `[rsp]` through `[rsp+255]`, indexed by byte value.
+Here, "reserves" means moving `rsp` by convention so your function does not overwrite return or caller data; it does not ask the kernel for fresh memory.
 This reserved region is your function's *stack frame*.
 
 In full, the pattern is reserve, use, then put it back:
@@ -26,7 +27,7 @@ As long as you don't `push` or `pop` anything inside the function, `rsp` stays p
 (One more detail: the stack starts as whatever bytes were left there before --- it is not zeroed. Clear your slots before you tally into them.)
 
 Write a function called `solve` that takes a pointer to a buffer in `rdi` and a length in `rsi`, and returns, in `rax`, the number of distinct byte values among those `rsi` bytes.
-You might find the instruction `mov [rsp+rcx], 1` useful for marking a given value (stored in `rcx`) as "present" in your buffer (pointed to by `rsp`).
+You might find the instruction `mov byte ptr [rsp+rcx], 1` useful for marking a given value (stored in `rcx`) as "present" in your scratch table (based at `rsp`).
 
 Build it into a shared library and hand it to the grader:
 

--- a/challenges/computing-101/the-stack-revisited/build-frame/challenge/.py/chal.py
+++ b/challenges/computing-101/the-stack-revisited/build-frame/challenge/.py/chal.py
@@ -42,8 +42,9 @@ def run_one(so_path, data, *, quiet):
         sys.stderr.flush()
         raise AssertionError(
             f"The harness crashed with {signame} on {data!r}. "
-            "If you made room with `sub rsp`, you must put the stack back the way you "
-            "found it before `ret` (`mov rsp, rbp; pop rbp`), or the `ret` jumps to the wrong place."
+            "Before `ret`, `rsp` must point back at the saved return address. "
+            "If you made room with `sub rsp, 256`, undo it with `add rsp, 256`; "
+            "if you built a different frame, restore `rsp` equivalently."
         )
     if p.returncode != 0:
         raise AssertionError(f"The harness exited abnormally (status {p.returncode}) on {data!r}.")

--- a/tools/feedback/discord-feedback
+++ b/tools/feedback/discord-feedback
@@ -808,8 +808,25 @@ def run_agent(
     return output_path
 
 
+def directions_block(directions: list[str]) -> str:
+    cleaned = [direction.strip() for direction in directions if direction.strip()]
+    if not cleaned:
+        return ""
+    lines = [
+        "",
+        "Operator directions for this run:",
+        "- Treat these as mandatory constraints for every recommendation, edit, validation step, and report.",
+        "- If a direction conflicts with repository safety rules or the explicit phase requirements above, stop and explain the conflict in the relevant artifact instead of ignoring it.",
+    ]
+    lines.extend(f"- {direction}" for direction in cleaned)
+    return "\n" + "\n".join(lines)
+
+
 def build_analysis_prompt(
-    transcript_path: pathlib.Path, jsonl_path: pathlib.Path, artifact_dir: pathlib.Path
+    transcript_path: pathlib.Path,
+    jsonl_path: pathlib.Path,
+    artifact_dir: pathlib.Path,
+    directions: list[str],
 ) -> str:
     return f"""Analyze recent pwn.college Discord feedback for actionable challenge/curriculum fixes.
 
@@ -835,11 +852,12 @@ Output markdown with these sections:
 3. Bridge/new challenge work that is not yet actionable, with exact blockers
 4. Non-actionable or deferred feedback
 5. Suggested validation plan
+{directions_block(directions)}
 """
 
 
 def build_implementation_prompt(
-    analysis_path: pathlib.Path, artifact_dir: pathlib.Path
+    analysis_path: pathlib.Path, artifact_dir: pathlib.Path, directions: list[str]
 ) -> str:
     return f"""Implement high-confidence pwn.college challenge/curriculum improvements from this feedback analysis:
 
@@ -861,11 +879,15 @@ When done, write a concise implementation note to {artifact_dir}/implementation-
 - changed challenge/module paths
 - what learner confusion each change addresses
 - any tests or playtests you recommend
+{directions_block(directions)}
 """
 
 
 def build_fix_prompt(
-    analysis_path: pathlib.Path, failure_dir: pathlib.Path, attempt: int
+    analysis_path: pathlib.Path,
+    failure_dir: pathlib.Path,
+    attempt: int,
+    directions: list[str],
 ) -> str:
     return f"""The feedback implementation has failing validation on attempt {attempt}.
 
@@ -875,6 +897,7 @@ Failure logs: {failure_dir}
 Read the failure logs, inspect the changed files, and make the smallest correct fixes.
 Follow AGENTS.md and .claude/skills/authoring-challenges/SKILL.md.
 Do not commit, push, open a PR, or edit generated Discord artifacts.
+{directions_block(directions)}
 """
 
 
@@ -882,6 +905,7 @@ def build_playtest_plan_prompt(
     analysis_path: pathlib.Path,
     changed_challenges: list[str],
     artifact_dir: pathlib.Path,
+    directions: list[str],
 ) -> str:
     changed = (
         "\n".join(f"- {challenge}" for challenge in changed_challenges) or "- none"
@@ -900,6 +924,7 @@ Return ONLY a JSON array. Each object must have:
 
 Prefer learner-realistic commands that exercise the revised description and solve path. If a challenge cannot be usefully cast noninteractively, omit it and explain why in {artifact_dir}/playtest-omissions.md.
 Do not include secrets or Discord transcript content.
+{directions_block(directions)}
 """
 
 
@@ -908,6 +933,7 @@ def build_cast_review_prompt(
     cast_dir: pathlib.Path,
     changed_challenges: list[str],
     artifact_dir: pathlib.Path,
+    directions: list[str],
 ) -> str:
     changed = (
         "\n".join(f"- {challenge}" for challenge in changed_challenges) or "- none"
@@ -925,6 +951,7 @@ Tasks:
 - If you find a small concrete issue, fix it. If you find a large or speculative issue, write it to {artifact_dir}/ux-deferred.md.
 - Do not commit, push, open a PR, or edit Discord transcripts.
 - Write {artifact_dir}/ux-review.md with findings and any changes made.
+{directions_block(directions)}
 """
 
 
@@ -934,6 +961,7 @@ def build_pr_body_prompt(
     ux_review: pathlib.Path,
     test_log: pathlib.Path,
     artifact_dir: pathlib.Path,
+    directions: list[str],
 ) -> str:
     return f"""Draft a GitHub PR body for this pwn.college feedback run.
 
@@ -965,6 +993,7 @@ Use exactly this top-level structure:
 - ...
 
 Write only that markdown document. The output will be saved under {artifact_dir}.
+{directions_block(directions)}
 """
 
 
@@ -1271,12 +1300,15 @@ def run_casts(
     analysis_path: pathlib.Path,
     changed_challenges: list[str],
     agent: str,
+    directions: list[str],
 ) -> pathlib.Path:
     cast_dir = artifact_dir / "casts"
     cast_dir.mkdir(parents=True, exist_ok=True)
     plan_output = run_agent(
         agent,
-        build_playtest_plan_prompt(analysis_path, changed_challenges, artifact_dir),
+        build_playtest_plan_prompt(
+            analysis_path, changed_challenges, artifact_dir, directions
+        ),
         repo=repo,
         artifact_dir=artifact_dir,
         output_name="playtest-plan.raw",
@@ -1410,6 +1442,11 @@ def create_pull_request(
     show_default=True,
 )
 @click.option(
+    "--directions",
+    multiple=True,
+    help="Additional mandatory natural-language directions for every agent phase. Repeatable.",
+)
+@click.option(
     "--apply", is_flag=True, help="Allow the selected agent to edit the repository."
 )
 @click.option(
@@ -1464,6 +1501,7 @@ def feedback_command(
     token_env,
     artifact_root,
     agent,
+    directions,
     apply,
     create_pr,
     draft_pr,
@@ -1480,6 +1518,7 @@ def feedback_command(
 ):
     """Turn recent public Discord feedback into challenge improvement PRs."""
     repo = git_root()
+    directions = [direction.strip() for direction in directions if direction.strip()]
     if create_pr and not apply:
         raise click.ClickException("--create-pr requires --apply.")
     if create_pr and skip_tests:
@@ -1544,6 +1583,7 @@ def feedback_command(
                 "channels": len(channels),
                 "include_threads": include_threads,
                 "include_authors": include_authors,
+                "directions": directions,
             },
             indent=2,
             sort_keys=True,
@@ -1556,7 +1596,7 @@ def feedback_command(
 
     analysis_path = run_agent(
         agent,
-        build_analysis_prompt(transcript_path, jsonl_path, artifact_dir),
+        build_analysis_prompt(transcript_path, jsonl_path, artifact_dir, directions),
         repo=repo,
         artifact_dir=artifact_dir,
         output_name="analysis.md",
@@ -1567,7 +1607,7 @@ def feedback_command(
 
     run_agent(
         agent,
-        build_implementation_prompt(analysis_path, artifact_dir),
+        build_implementation_prompt(analysis_path, artifact_dir, directions),
         repo=repo,
         artifact_dir=artifact_dir,
         output_name="implementation-agent.log",
@@ -1595,7 +1635,7 @@ def feedback_command(
                 failure_dir = artifact_dir / f"test-logs-attempt-{attempt}"
                 run_agent(
                     agent,
-                    build_fix_prompt(analysis_path, failure_dir, attempt),
+                    build_fix_prompt(analysis_path, failure_dir, attempt, directions),
                     repo=repo,
                     artifact_dir=artifact_dir,
                     output_name=f"fix-agent-attempt-{attempt}.log",
@@ -1612,12 +1652,12 @@ def feedback_command(
             f"{len(changed_challenges)} changed challenge(s)"
         )
         cast_dir = run_casts(
-            repo, artifact_dir, analysis_path, changed_challenges, agent
+            repo, artifact_dir, analysis_path, changed_challenges, agent, directions
         )
         run_agent(
             agent,
             build_cast_review_prompt(
-                analysis_path, cast_dir, changed_challenges, artifact_dir
+                analysis_path, cast_dir, changed_challenges, artifact_dir, directions
             ),
             repo=repo,
             artifact_dir=artifact_dir,
@@ -1636,7 +1676,12 @@ def feedback_command(
     pr_body_agent_output = run_agent(
         agent,
         build_pr_body_prompt(
-            analysis_path, implementation_notes, ux_review, test_log, artifact_dir
+            analysis_path,
+            implementation_notes,
+            ux_review,
+            test_log,
+            artifact_dir,
+            directions,
         ),
         repo=repo,
         artifact_dir=artifact_dir,


### PR DESCRIPTION
## Summary
- Addresses feedback from sanitized public Discord messages for active Computing 101 challenges.
- `challenges/computing-101/nibbling-on-numbers/mixed-conversions/DESCRIPTION.md` and `challenge/mixed`: make the capstone less typo-punishing by allowing three attempts per conversion, making prompts explicitly ask to convert the source value to the target form, and updating text that previously implied every answer had to be correct “in a row.”
- `challenges/computing-101/the-stack-revisited/build-frame/DESCRIPTION.md`: clarify that reserving stack space means moving `rsp` by convention, not requesting kernel memory, and fix the example marker instruction to `mov byte ptr [rsp+rcx], 1`.
- `challenges/computing-101/the-stack-revisited/build-frame/challenge/.py/chal.py`: improve the crash diagnostic so learners are told to restore `rsp` to the saved return address, with `add rsp, 256` as the inverse of the described frame setup.

## Validation
- Reviewed terminal casts for the `mixed-conversions` retry-and-solve path and the `build-frame` solve path.
- Ran `as -o /tmp/build-frame-hint.o /tmp/build-frame-hint.s`, `python3 -m py_compile` for the changed Python challenge scripts, and `git diff --check`.
- Ran `nix develop --command pwnshop test challenges/computing-101/nibbling-on-numbers/mixed-conversions` and `nix develop --command pwnshop test challenges/computing-101/the-stack-revisited/build-frame`; both passed inside `nix develop` (`2 challenges, 2 testcases`).

## Notes / deferred follow-ups
- ROP/reversing-tooling and kernel-exploitation feedback was not changed here because the identified targets map to `challenges/legacy/**` or have no active `challenges/program-security` target in this checkout, and this run was directed to ignore `./legacy`.
