### PR TITLE
Address challenge feedback from Discord

### DIFF
--- a/challenges/computing-101/assembly-assortment/module.yml
+++ b/challenges/computing-101/assembly-assortment/module.yml
@@ -41,22 +41,6 @@ resources:
     Back in [Opening the Flag, with RIP](/computing-101/hello-hackers/open-read-write-rip-relative), you used a label and `lea` to pass the address of stored bytes to `open`.
     In [Examining Memory with GDB](/computing-101/introspecting/gdb-examine-argv1), you used `x/s` to display the string at an address.
 
-    The same pattern works for data that you store yourself.
-    If `label` names bytes in your assembly, `lea reg, [rip+label]` puts the address of those bytes into `reg`.
-    `mov reg, [rip+label]` is different: it reads the bytes at that address.
-
-    ```asm
-    lea rdx, [rip+nums]      # rdx = address of the array
-    mov eax, [rdx+rcx*4]     # eax = nums[rcx], with 4-byte elements
-
-    nums:
-        .long 10, 20, 30
-    ```
-
-    The `[rip+label]` syntax is a little odd.
-    In the machine code, x86 stores the distance from the next instruction to `label`; the CPU adds that distance to `rip` at runtime.
-    That is why the same code can still find its own data even when the program is loaded at a different address.
-
     The next challenge combines those ideas in a binary you are reversing.
     Instead of looking for every secret byte as an immediate inside a `cmp`, step through the code until a register points at the stored string, then examine that address as a string:
 

--- a/challenges/computing-101/assembly-assortment/module.yml
+++ b/challenges/computing-101/assembly-assortment/module.yml
@@ -41,6 +41,22 @@ resources:
     Back in [Opening the Flag, with RIP](/computing-101/hello-hackers/open-read-write-rip-relative), you used a label and `lea` to pass the address of stored bytes to `open`.
     In [Examining Memory with GDB](/computing-101/introspecting/gdb-examine-argv1), you used `x/s` to display the string at an address.
 
+    The same pattern works for data that you store yourself.
+    If `label` names bytes in your assembly, `lea reg, [rip+label]` puts the address of those bytes into `reg`.
+    `mov reg, [rip+label]` is different: it reads the bytes at that address.
+
+    ```asm
+    lea rdx, [rip+nums]      # rdx = address of the array
+    mov eax, [rdx+rcx*4]     # eax = nums[rcx], with 4-byte elements
+
+    nums:
+        .long 10, 20, 30
+    ```
+
+    The `[rip+label]` syntax is a little odd.
+    In the machine code, x86 stores the distance from the next instruction to `label`; the CPU adds that distance to `rip` at runtime.
+    That is why the same code can still find its own data even when the program is loaded at a different address.
+
     The next challenge combines those ideas in a binary you are reversing.
     Instead of looking for every secret byte as an immediate inside a `cmp`, step through the code until a register points at the stored string, then examine that address as a string:
 

--- a/challenges/computing-101/control-flow/switch/DESCRIPTION.md
+++ b/challenges/computing-101/control-flow/switch/DESCRIPTION.md
@@ -48,6 +48,13 @@ For example, if you are in gdb at the instruction `mov rax, [rax*8+0x1337000]` (
 (gdb)
 ```
 
+Once you find the table entry that points somewhere different, convert its table position back into the input byte.
+Use the address of that table slot (the address on the left side of the `x/a` output), not the address stored inside it.
+Subtract the table base from that slot address to get its offset into the table.
+Then divide by 8, because each table entry is an 8-byte address.
+In the example above, the unusual entry is at `0x1337310`, so `0x1337310 - 0x1337000 = 0x310`, and `0x310 / 8 = 98`.
+That means the input byte has value `98`, which ASCII represents as `'b'`.
+
 **HINT:**
 You can also print out *several* jump table entries at the same time:
 

--- a/challenges/computing-101/hello-hackers/open-read-write-rip-relative/DESCRIPTION.md
+++ b/challenges/computing-101/hello-hackers/open-read-write-rip-relative/DESCRIPTION.md
@@ -20,7 +20,7 @@ path:
 The `.asciz` directive emits the bytes of the string along with the terminating zero byte that Linux expects at the end of a filename.
 The `path:` label marks where those bytes start.
 
-That leaves one problem: to pass this pass into the `open` syscall, you need to set its address in `rdi`.
+That leaves one problem: to pass this path into the `open` syscall, you need to set its address in `rdi`.
 In the old days, programs would always be loaded to the same address in memory, and so you could hardcode this, as so:
 
 ```asm

--- a/challenges/computing-101/the-stack-revisited/build-frame/DESCRIPTION.md
+++ b/challenges/computing-101/the-stack-revisited/build-frame/DESCRIPTION.md
@@ -42,35 +42,4 @@ hacker@dojo:~$ /challenge/check solve.so
 **HINT:**
 You'll need _two_ loops in this level, one after the other: one to mark each value you see, and another one to count them afterwards.
 
-**Debugging your solution.**
-Because your submitted code is a function inside a shared library, there is no `_start` for `gdb` to run directly.
-For a debugging build, add a temporary `_start` that sets up a small byte buffer, calls `solve`, and then exits with the return value.
-Keep your `.global solve` and `solve:` function in the same file; this `_start` is just extra scaffolding for the debug executable.
-
-```asm
-.global _start
-_start:
-    lea rdi, [rip+sample]        # first argument: pointer to bytes
-    mov rsi, sample_end-sample   # second argument: number of bytes
-    int3                         # optional: gdb breaks here
-    call solve
-    mov rdi, rax                 # exit code = returned distinct count
-    mov rax, 60
-    syscall
-
-sample:
-    .byte 0x41, 0x42, 0x41, 0x43
-sample_end:
-```
-
-Assemble and link that version as a normal executable, then run it in `gdb`:
-
-```console
-hacker@dojo:~$ as -o debug.o debug.s
-hacker@dojo:~$ ld -o debug debug.o
-hacker@dojo:~$ gdb ./debug
-(gdb) run
-```
-
-Step through from the `int3`, watch `rsp` before and after `solve`, and make sure your function reaches `ret` with `rsp` restored.
-When you are ready to submit, build the shared library version with `ld -shared` as usual.
+For debugging a submitted function inside a shared library, refer back to [Writing From a Shared Library](/computing-101/control-flow/callee-write).

--- a/challenges/computing-101/the-stack-revisited/build-frame/DESCRIPTION.md
+++ b/challenges/computing-101/the-stack-revisited/build-frame/DESCRIPTION.md
@@ -41,3 +41,36 @@ hacker@dojo:~$ /challenge/check solve.so
 ----
 **HINT:**
 You'll need _two_ loops in this level, one after the other: one to mark each value you see, and another one to count them afterwards.
+
+**Debugging your solution.**
+Because your submitted code is a function inside a shared library, there is no `_start` for `gdb` to run directly.
+For a debugging build, add a temporary `_start` that sets up a small byte buffer, calls `solve`, and then exits with the return value.
+Keep your `.global solve` and `solve:` function in the same file; this `_start` is just extra scaffolding for the debug executable.
+
+```asm
+.global _start
+_start:
+    lea rdi, [rip+sample]        # first argument: pointer to bytes
+    mov rsi, sample_end-sample   # second argument: number of bytes
+    int3                         # optional: gdb breaks here
+    call solve
+    mov rdi, rax                 # exit code = returned distinct count
+    mov rax, 60
+    syscall
+
+sample:
+    .byte 0x41, 0x42, 0x41, 0x43
+sample_end:
+```
+
+Assemble and link that version as a normal executable, then run it in `gdb`:
+
+```console
+hacker@dojo:~$ as -o debug.o debug.s
+hacker@dojo:~$ ld -o debug debug.o
+hacker@dojo:~$ gdb ./debug
+(gdb) run
+```
+
+Step through from the `int3`, watch `rsp` before and after `solve`, and make sure your function reaches `ret` with `rsp` restored.
+When you are ready to submit, build the shared library version with `ld -shared` as usual.


### PR DESCRIPTION
## Summary
- Addressed feedback from sanitized public Discord messages in Computing 101.
- Updated `challenges/computing-101/control-flow/switch/DESCRIPTION.md` to explain how to recover the intended byte from the unusual jump-table slot: subtract the table base, divide by the 8-byte entry size, and convert the resulting byte value with ASCII. The wording now distinguishes the table slot address from the target address stored in that slot.
- Updated `challenges/computing-101/the-stack-revisited/build-frame/DESCRIPTION.md` with a temporary `_start` debugging harness for shared-library `solve(data, n)` submissions, so learners can reproduce checker-style calls under `gdb` when their `.so` crashes.
- Updated `challenges/computing-101/assembly-assortment/module.yml` to expand the stored-data resource with a later RIP-relative refresher for learner-defined labels, including `lea reg, [rip+label]`, reading through `[rip+label]`, and indexed access via `[reg+index*scale]`.
- Updated `challenges/computing-101/hello-hackers/open-read-write-rip-relative/DESCRIPTION.md` to fix the typo “pass this pass” to “pass this path.”

## Validation
- Assembled and linked the new `build-frame` debugging snippet with `as`/`ld`.
- Assembled and linked the new RIP-relative array snippet with `as`/`ld`.
- Reviewed the relevant asciinema casts with `asciinema cat` and checked them against the revised descriptions and runtime behavior.
- Ran `tools/dojo/parse-dojo-yml challenges/computing-101/dojo.yml`, which parsed successfully.
- Ran `git diff --check`.
- `pwnshop` test attempt 4 passed: 3 challenges, 3 testcases.

## Notes / deferred follow-ups
- No deferred follow-ups for the implemented scope.
- Legacy-only reports were ignored per run direction.
