### PR TITLE
Add pre-commit hook rejecting unencrypted secret tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,7 +68,10 @@ per archetype (templated web/service, interpreted checker, compiled SUID binary,
   qualify a pass with its environment.
 - **Git/comms:** on an unpushed WIP branch just amend obvious fixes (no permission menus);
   state persistence precisely (working-tree vs committed vs pushed); never assert an
-  uncommitted change is "the user's" without evidence.
+  uncommitted change is "the user's" without evidence. **Before every commit run the
+  secret-test encryption hook** (`tools/git-hooks/pre-commit`, see below) — or install it
+  once so `git commit` runs it for you — so an unencrypted `tests_private` solution never
+  lands in history.
 
 ## Key Commands
 
@@ -114,6 +117,31 @@ pwnshop run --user 0 --volume /tmp/debug challenges/web-security/path-traversal-
 ```
 
 DO NOT run these scripts without pwnshop: the dependencies are not installed in the host, and some of these challenges do permanent damage to their environment.
+
+### Secret-Test Encryption (pre-commit hook)
+
+Everything under `tests_private/` is the solution and **must** be git-crypt encrypted in
+every commit (each `challenges/MODULE_ID/.gitattributes` routes `tests_private/` through a
+per-module `git-crypt` filter). A plaintext `tests_private` file leaks the flag-grade solve
+into history.
+
+`tools/git-hooks/pre-commit` enforces this against the **staged index**. Entering `nix
+develop` installs it automatically (idempotent, and it won't clobber a pre-existing hook), so
+`git commit` runs it for you. To install by hand, or to run it on demand:
+
+```bash
+# install once per clone (the symlink resolves from any working directory)
+ln -sf ../../tools/git-hooks/pre-commit "$(git rev-parse --git-dir)/hooks/pre-commit"
+
+# or run on demand, after `git add` and before `git commit`
+tools/git-hooks/pre-commit
+```
+
+It blocks the commit when a staged file is unencrypted but either (a) `.gitattributes` routes
+it through a `git-crypt` filter, or (b) lives under `tests_private/` (so a missing or
+misconfigured module `.gitattributes` can't slip plaintext through). On a hit, `git-crypt
+unlock` and re-`git add` the file so the clean filter encrypts it, then commit. This catches
+the leak locally, before the `check-encryption` CI gate would reject it.
 
 ## Architecture
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,8 +130,8 @@ develop` installs it automatically (idempotent, and it won't clobber a pre-exist
 `git commit` runs it for you. To install by hand, or to run it on demand:
 
 ```bash
-# install once per clone (the symlink resolves from any working directory)
-ln -sf ../../tools/git-hooks/pre-commit "$(git rev-parse --git-dir)/hooks/pre-commit"
+# install once per clone (uses Git's resolved hooks dir, so worktrees work too)
+ln -sf ../../tools/git-hooks/pre-commit "$(git rev-parse --git-path hooks)/pre-commit"
 
 # or run on demand, after `git add` and before `git commit`
 tools/git-hooks/pre-commit

--- a/flake.nix
+++ b/flake.nix
@@ -89,13 +89,20 @@
             ];
             shellHook = ''
               # Install the secret-test encryption pre-commit hook (idempotent,
-              # non-destructive): symlink it in unless a foreign hook is present.
-              if git_dir="$(git rev-parse --git-dir 2>/dev/null)"; then
-                hook="$git_dir/hooks/pre-commit"
-                target="../../tools/git-hooks/pre-commit"
+              # non-destructive). Resolve the path Git actually runs the hook from
+              # -- honoring core.hooksPath and the shared hooks dir of a linked
+              # worktree -- and point it at the main checkout's copy so removing a
+              # worktree can't break it.
+              if git rev-parse --git-dir >/dev/null 2>&1; then
+                hooks_dir="$(git config --path core.hooksPath 2>/dev/null || true)"
+                [ -n "$hooks_dir" ] || hooks_dir="$(git rev-parse --git-path hooks)"
+                root="$(cd "$(git rev-parse --git-common-dir)/.." && pwd)"
+                hook="$hooks_dir/pre-commit"
+                target="$root/tools/git-hooks/pre-commit"
                 if [ ! -e "$hook" ] && [ ! -L "$hook" ]; then
+                  mkdir -p "$hooks_dir"
                   ln -s "$target" "$hook"
-                elif [ "$(readlink "$hook" 2>/dev/null)" != "$target" ]; then
+                elif [ "$(readlink -f "$hook" 2>/dev/null)" != "$(readlink -f "$target" 2>/dev/null)" ]; then
                   echo "note: $hook already exists; not overwriting (encryption hook: tools/git-hooks/pre-commit)" >&2
                 fi
               fi

--- a/flake.nix
+++ b/flake.nix
@@ -88,6 +88,18 @@
               uv
             ];
             shellHook = ''
+              # Install the secret-test encryption pre-commit hook (idempotent,
+              # non-destructive): symlink it in unless a foreign hook is present.
+              if git_dir="$(git rev-parse --git-dir 2>/dev/null)"; then
+                hook="$git_dir/hooks/pre-commit"
+                target="../../tools/git-hooks/pre-commit"
+                if [ ! -e "$hook" ] && [ ! -L "$hook" ]; then
+                  ln -s "$target" "$hook"
+                elif [ "$(readlink "$hook" 2>/dev/null)" != "$target" ]; then
+                  echo "note: $hook already exists; not overwriting (encryption hook: tools/git-hooks/pre-commit)" >&2
+                fi
+              fi
+
               if [ "$(id -u)" -eq 0 ]; then
                 export DOCKER_HOST="$(${lib.getExe pwn-challenge-runtime})"
               elif command -v sudo >/dev/null 2>&1; then

--- a/tools/git-hooks/pre-commit
+++ b/tools/git-hooks/pre-commit
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+#
+# pre-commit hook: refuse to commit secret test files that should be git-crypt
+# encrypted but are staged as plaintext.
+#
+# Two independent rules, both enforced against the *staged* content (the index),
+# which is exactly what the commit will record:
+#
+#   (a) any file that .gitattributes routes through a git-crypt filter must be
+#       encrypted in the index;
+#   (b) any file under a tests_private/ directory must be encrypted in the index,
+#       even if .gitattributes is missing or misconfigured for its module
+#       (a new module without a .gitattributes, a typo'd filter name, ...).
+#
+# git-crypt stores an encrypted blob with a 10-byte magic header, "\0GITCRYPT\0".
+# A staged blob that should be encrypted but lacks that header was cleaned
+# without the filter -- git-crypt locked, key missing, .gitattributes absent --
+# and would leak the plaintext solution if committed.
+#
+# Run it by hand after staging and before committing, or install it as the
+# repo's hook (resolves from any working directory):
+#
+#   ln -sf ../../tools/git-hooks/pre-commit "$(git rev-parse --git-dir)/hooks/pre-commit"
+
+set -euo pipefail
+
+# hex of git-crypt's header magic: 0x00 "GITCRYPT" 0x00
+readonly GITCRYPT_MAGIC_HEX="00474954435259505400"
+
+# Diff the index against HEAD, or against the empty tree on the first commit.
+if git rev-parse --verify --quiet HEAD >/dev/null; then
+    against=HEAD
+else
+    against=$(git hash-object -t tree /dev/null)
+fi
+
+errors=()
+
+# Staged additions/copies/modifications/renames/type-changes (deletions skipped).
+while IFS= read -r -d '' path; do
+    reason=
+
+    # Rule (b): anything under tests_private/ must be encrypted, no matter what
+    # .gitattributes says.
+    case "$path" in
+        tests_private/* | */tests_private/*)
+            reason="under tests_private/"
+            ;;
+    esac
+
+    # Rule (a): anything .gitattributes routes through a git-crypt filter.
+    if [ -z "$reason" ]; then
+        filter=$(git check-attr filter -- "$path" | sed 's/.*: filter: //')
+        case "$filter" in
+            git-crypt*) reason="gitattributes filter=$filter" ;;
+        esac
+    fi
+
+    [ -n "$reason" ] || continue
+
+    # Empty blobs carry no header and leak nothing; git-crypt leaves them empty.
+    size=$(git cat-file -s ":$path")
+    [ "$size" -gt 0 ] || continue
+
+    # Read the whole blob (test files are tiny) and slice the header, rather than
+    # `head -c`, whose early pipe close would SIGPIPE git cat-file under pipefail.
+    header=$(git cat-file blob ":$path" | od -An -v -tx1 | tr -d ' \n')
+    if [ "${header:0:20}" != "$GITCRYPT_MAGIC_HEX" ]; then
+        errors+=("  $path  ($reason)")
+    fi
+done < <(git diff --cached -z --name-only --diff-filter=ACMRT "$against")
+
+if [ "${#errors[@]}" -gt 0 ]; then
+    {
+        echo "pre-commit: refusing to commit unencrypted secret test files."
+        echo
+        echo "These staged files must be git-crypt encrypted but are plaintext in the index:"
+        printf '%s\n' "${errors[@]}"
+        echo
+        echo "Unlock git-crypt and re-stage so the clean filter encrypts them:"
+        echo "    git-crypt unlock           # supply the module key(s) if needed"
+        echo "    git add -- <file>...       # re-stage to run the filter"
+        echo
+        echo "Bypass only if you are certain (NOT recommended): git commit --no-verify"
+    } >&2
+    exit 1
+fi


### PR DESCRIPTION
## What

Adds `tools/git-hooks/pre-commit`, which validates the **staged index** and blocks a commit when a staged file is plaintext but should be git-crypt encrypted. Two independent rules:

- **(a)** `.gitattributes` routes the file through a `git-crypt` filter, or
- **(b)** the file lives under a `tests_private/` directory — checked by path, independent of gitattributes, so a missing or typo'd module `.gitattributes` can't slip a plaintext solution through.

"Encrypted" = the staged blob begins with git-crypt's 10-byte magic header `\x00GITCRYPT\x00`. A plaintext blob (git-crypt locked, key missing, gitattributes absent) is rejected with a remediation message.

## Why

`tests_private/` holds the flag-grade solution. Today the only guard is the `check-encryption` CI job, which runs *after* a push. This catches the leak locally, before it's ever committed.

## Details

- **Fail-closed** (`set -e`): any unexpected error aborts the commit rather than letting a leak through. NUL-safe file iteration; skips deletions; skips empty blobs (git-crypt leaves them empty and they leak nothing).
- `nix develop` installs the hook automatically (idempotent, and it won't clobber a pre-existing hook). Manual install / on-demand usage documented in `AGENTS.md`.
- Documented in `AGENTS.md` (CLAUDE.md symlinks to it): a new **Secret-Test Encryption** subsection plus a pointer in the **Git/comms** authoring rule.

## Testing

Verified against the real index:

| Case | Result |
|---|---|
| Nothing staged | allow |
| Properly-encrypted `tests_private` file | allow |
| Plaintext `tests_private` in a module with no `.gitattributes` (rule b) | **block** |
| Plaintext file with a `git-crypt` filter, not under `tests_private` (rule a) | **block** |
| Normal source file | allow |

This PR's own commit was made with the hook installed and active.

🤖 Generated with [Claude Code](https://claude.com/claude-code)