### PR TITLE
Address challenge feedback from Discord

### DIFF
--- a/challenges/computing-101/control-flow/switch/DESCRIPTION.md
+++ b/challenges/computing-101/control-flow/switch/DESCRIPTION.md
@@ -60,7 +60,7 @@ You can also print the whole jump table at the same time.
 The output will be long, but it starts like this:
 
 ```gdb
-(gdb) x/256ag 0x1337000
+(gdb) x/256a 0x1337000
 0x1337000:  0x400100  0x400100
 0x1337010:  0x400100  0x400100
 ...

--- a/challenges/computing-101/control-flow/switch/DESCRIPTION.md
+++ b/challenges/computing-101/control-flow/switch/DESCRIPTION.md
@@ -60,7 +60,7 @@ You can also print the whole jump table at the same time.
 The output will be long, but it starts like this:
 
 ```gdb
-(gdb) x/256a 0x1337000
+(gdb) x/256ag 0x1337000
 0x1337000:  0x400100  0x400100
 0x1337010:  0x400100  0x400100
 ...

--- a/challenges/computing-101/control-flow/switch/DESCRIPTION.md
+++ b/challenges/computing-101/control-flow/switch/DESCRIPTION.md
@@ -56,12 +56,18 @@ In the example above, the unusual entry is at `0x1337310`, so `0x1337310 - 0x133
 That means the input byte has value `98`, which ASCII represents as `'b'`.
 
 **HINT:**
-You can also print out *several* jump table entries at the same time:
+You can also print the whole jump table at the same time.
+The output will be long, but it starts like this:
 
 ```gdb
-(gdb) x/3a 0x1337000
-0x1337000:  0x400100
-0x1337008:  0x400100
-0x1337010:  0x400100
+(gdb) x/256a 0x1337000
+0x1337000:  0x400100  0x400100
+0x1337010:  0x400100  0x400100
+...
 (gdb)
 ```
+
+The number after `x/` is how many entries gdb should print.
+Since the input byte chooses one of 256 entries, and each entry is one 8-byte code address, this lets you scan the table for the one address that differs.
+If gdb prints multiple entries on one line, the address on the left is the first entry on that line; the next entry is 8 bytes later.
+As in the previous challenge, use gdb to understand the binary, then run `/challenge/reverse-me` directly with the recovered byte to get the flag.

--- a/challenges/linux-luminarium/piping/tee/challenge/college
+++ b/challenges/linux-luminarium/piping/tee/challenge/college
@@ -4,7 +4,7 @@ sleep 5
 DIR=$(/bin/dirname ${BASH_SOURCE[0]})
 if ! $DIR/chio.py --check_stdin_pipe tee 2>/dev/null && ! $DIR/chio.py --check_stdin_pipe challenge_shellscript 2>/dev/null
 then
-	fold -s <<< "/challenge/secret needs to the on the receiving end of the output of '/challenge/pwn' (or 'tee' for debugging)."
+	fold -s <<< "/challenge/college needs to be on the receiving end of the output of '/challenge/pwn' (or 'tee' for debugging)."
 	exit 1
 fi
 

--- a/challenges/program-misuse/common/Dockerfile.j2
+++ b/challenges/program-misuse/common/Dockerfile.j2
@@ -1,6 +1,7 @@
 FROM ubuntu:24.04
 
-RUN apt-get update && apt-get install --no-install-recommends -yqq \
+RUN export DEBIAN_FRONTEND=noninteractive && \
+    apt-get update && apt-get install --no-install-recommends -yqq \
     binutils \
     bsdextrautils \
     bzip2 \
@@ -11,6 +12,8 @@ RUN apt-get update && apt-get install --no-install-recommends -yqq \
     genisoimage \
     less \
     make \
+    man-db \
+    manpages \
     nano \
     openssh-client \
     python-is-python3 \
@@ -22,6 +25,7 @@ RUN apt-get update && apt-get install --no-install-recommends -yqq \
     whiptail \
     xxd \
     zip && \
+    yes | unminimize && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
 RUN usermod -md /home/hacker -l hacker ubuntu && \


### PR DESCRIPTION
THIS MESSAGE IS GENERATED BY AN AUTOMATED PROCESS.

## Summary
- Addressed feedback from sanitized public Discord messages in three active, non-legacy challenge areas.
- Updated `challenges/program-misuse/common/Dockerfile.j2` so the shared Program Misuse image restores manpage support, matching the module guidance that learners should use `man` for tools such as `socat` and `whiptail`.
- Updated `challenges/linux-luminarium/piping/tee/challenge/college` so the runtime receiving-end error points to `/challenge/college` instead of `/challenge/secret`, and fixed the typo in that message.
- Updated `challenges/computing-101/control-flow/switch/DESCRIPTION.md` to make the GDB jump-table hint more actionable: it now shows `x/256a`, explains 256 entries and 8-byte addresses, clarifies multi-entry GDB output, and reminds learners to run `/challenge/reverse-me` directly after analysis.

## Validation
- Verified Ubuntu 24.04 minimized-image behavior for `socat` and `whiptail` manpages, then verified the added `man-db` / `manpages` / `unminimize` sequence renders `man socat` and `man whiptail`.
- Replayed/read the recorded UX casts for the `switch` GDB workflow and the `tee` intercept-and-replay workflow.
- Ran `bash -n challenges/linux-luminarium/piping/tee/challenge/college`.
- Ran `git diff --check`.
- Final pwnshop test log reports: `All tests passed (53 challenges, 53 testcases)`.

## Notes / deferred follow-ups
- Intro to Programming Languages Prolog feedback is deferred because the relevant dojo source is not present in this checkout, so there is no reviewable path or validation command here.
- Feedback mapped only to `./legacy` was intentionally not changed for this run.
