### PR TITLE
Stop discord-feedback cast hangs and make recovery graceful

### DIFF
--- a/tools/feedback/discord-feedback
+++ b/tools/feedback/discord-feedback
@@ -16,6 +16,7 @@ import queue
 import re
 import shlex
 import shutil
+import signal
 import subprocess
 import sys
 import tempfile
@@ -46,6 +47,12 @@ MAX_DISCORD_SERVER_ERROR_RETRIES = 5
 IMAGE_ATTACHMENT_EXTENSIONS = (".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp")
 MAX_IMAGE_ATTACHMENT_BYTES = 25 * 1024 * 1024
 STATUS_HEARTBEAT_SECONDS = 30
+# A noninteractive cast should finish in seconds. Cap it so a hang-prone playtest command
+# (e.g. one that pipes from a long-lived or SUID-root process it cannot kill) is aborted
+# quickly by `pwnshop run --timeout`, which tears the container down to stop it for real.
+# The outer stream_command watchdog is a slightly longer backstop for a wedged pwnshop.
+CAST_TIMEOUT_SECONDS = 120
+CAST_WATCHDOG_SECONDS = CAST_TIMEOUT_SECONDS + 60
 STATUS_TEXT_LIMIT = 160
 AGENT_MESSAGE_TEXT_LIMIT = 700
 COMMAND_OUTPUT_TEXT_LIMIT = 260
@@ -771,6 +778,35 @@ def insert_before_stdin_prompt(args: list[str], additions: list[str]) -> list[st
     return [*args, *additions]
 
 
+def terminate_process_tree(
+    process: "subprocess.Popen[Any]", *, grace_seconds: float = 5.0
+) -> None:
+    """Best-effort teardown of a child and everything it spawned.
+
+    stream_command starts children with start_new_session=True, so the process and its
+    descendants share a process group. Signalling the group (rather than the lone leader)
+    reaps the grandchildren -- here `nix -> pwnshop -> asciinema -> docker exec` -- that a
+    bare process.kill() would orphan. SIGINT first so pwnshop's own cleanup (tearing down
+    the challenge container) can run; escalate to SIGKILL only if it ignores us.
+    """
+    if process.poll() is not None:
+        return
+    try:
+        pgid = os.getpgid(process.pid)
+    except ProcessLookupError:
+        return
+    for sig in (signal.SIGINT, signal.SIGKILL):
+        try:
+            os.killpg(pgid, sig)
+        except ProcessLookupError:
+            return
+        try:
+            process.wait(timeout=grace_seconds)
+            return
+        except subprocess.TimeoutExpired:
+            continue
+
+
 def stream_command(
     command: list[str],
     *,
@@ -786,6 +822,7 @@ def stream_command(
     last_heartbeat = started
     timed_out = False
     input_file = None
+    process = None
 
     if input_text is not None:
         input_file = tempfile.TemporaryFile(mode="w+", encoding="utf-8")
@@ -805,6 +842,7 @@ def stream_command(
                 stderr=subprocess.STDOUT,
                 text=True,
                 bufsize=1,
+                start_new_session=True,
             )
             output_queue = queue.Queue()
 
@@ -822,7 +860,7 @@ def stream_command(
             while True:
                 if timeout and time.monotonic() - started > timeout:
                     timed_out = True
-                    process.kill()
+                    terminate_process_tree(process)
                     click.echo(
                         f"{heartbeat_label or 'Command'} timed out after {timeout}s"
                     )
@@ -858,6 +896,11 @@ def stream_command(
             return_code = process.wait()
             reader.join(timeout=1)
     finally:
+        # Covers Ctrl-C and any unexpected error: tear down the child tree (and the
+        # challenge container it spawned) instead of orphaning it. No-op on the normal and
+        # timeout paths, where the process has already exited.
+        if process is not None:
+            terminate_process_tree(process)
         if input_file:
             input_file.close()
 
@@ -1269,6 +1312,12 @@ Return ONLY a JSON array. Each object must have:
 - "command": array of command arguments to run inside `pwnshop run`; it must exit without human input
 - "title": short filesystem-safe title
 - "purpose": what UX path this cast validates
+
+The command runs noninteractively as an unprivileged user and must terminate on its own within a few seconds. Hard constraints:
+- Never block on a long-lived or backgrounded process. Do not pipe (`|`, `tee`) the output of a process that keeps running (a server, a `sleep`, a daemon) into another command -- the pipe never closes and the cast hangs.
+- The challenge's own processes are often SUID-root; a command running as the unprivileged user CANNOT signal or `kill`/`timeout` them. Do not rely on `timeout`, `kill`, or Ctrl-C to stop a privileged process.
+- To capture output from a process that lingers, background it to a file and read the file (e.g. `proc > /tmp/out & sleep 1; grep ... /tmp/out`), or use `grep -m1`/`head` on a process that exits on its own. Leave any lingering process running; the container is torn down afterward.
+- Mirror the challenge's real solve (see its tests_private solve) rather than inventing a new technique.
 
 Prefer learner-realistic commands that exercise the revised description and solve path. If a challenge cannot be usefully cast noninteractively, omit it and explain why in {artifact_dir}/playtest-omissions.md.
 Do not include secrets or Discord transcript content.
@@ -1731,11 +1780,18 @@ def run_casts(
         json.dumps(plan, indent=2, sort_keys=True) + "\n"
     )
 
+    # Casts are a UX-review aid, not a gate: one bad playtest command (a hang, a nonzero
+    # exit) must not abort the whole feedback run. Record every failure and keep going so
+    # the cast-review agent still sees the casts that did record.
+    failures: list[str] = []
     for index, item in enumerate(plan, start=1):
         challenge = item.get("challenge")
         command = item.get("command")
         if not challenge or not isinstance(command, list):
-            raise click.ClickException(f"Invalid playtest item #{index}: {item!r}")
+            message = f"playtest item #{index} is malformed: {item!r}"
+            click.echo(f"Skipping {message}")
+            failures.append(message)
+            continue
         title = safe_title(item.get("title") or pathlib.Path(challenge).name)
         cast_path = cast_dir / f"{index:02d}-{title}.cast"
         log_path = cast_dir / f"{index:02d}-{title}.log"
@@ -1744,19 +1800,44 @@ def run_casts(
             "run",
             "--cast-to",
             str(cast_path),
+            "--timeout",
+            str(CAST_TIMEOUT_SECONDS),
             challenge,
             *[str(part) for part in command],
         ]
-        rc = run_logged(
-            pwnshop_invocation(repo, pwnshop_args),
-            cwd=repo,
-            log_path=log_path,
-            timeout=600,
-        )
-        if rc != 0:
-            raise click.ClickException(
-                f"playtest cast failed for {challenge}; see {log_path}"
+        try:
+            rc = run_logged(
+                pwnshop_invocation(repo, pwnshop_args),
+                cwd=repo,
+                log_path=log_path,
+                timeout=CAST_WATCHDOG_SECONDS,
             )
+        except subprocess.TimeoutExpired:
+            message = (
+                f"cast {index} for {challenge} ({title}) wedged past "
+                f"{CAST_WATCHDOG_SECONDS}s and was killed; see {log_path}"
+            )
+        else:
+            message = (
+                f"cast {index} for {challenge} ({title}) exited {rc}; see {log_path}"
+                if rc != 0
+                else ""
+            )
+        if message:
+            click.echo(message)
+            failures.append(message)
+
+    if failures:
+        summary_path = cast_dir / "cast-failures.md"
+        summary_path.write_text(
+            "# Playtest casts that did not record cleanly\n\n"
+            + "\n".join(f"- {line}" for line in failures)
+            + "\n"
+        )
+        click.echo(
+            f"{len(failures)}/{len(plan)} playtest cast(s) failed; "
+            f"continuing with the rest (details in {summary_path})"
+        )
     return cast_dir
 
 

--- a/tools/pwnshop/src/pwnshop/commands/run.py
+++ b/tools/pwnshop/src/pwnshop/commands/run.py
@@ -38,8 +38,19 @@ logger = logging.getLogger(__name__)
     default=None,
     help="Record the session to an asciinema v2 .cast file (replay with `asciinema play`).",
 )
+@click.option(
+    "--timeout",
+    "timeout",
+    type=float,
+    default=None,
+    help=(
+        "Abort the session after this many seconds. Intended for noninteractive/cast "
+        "runs: the container is always torn down afterwards, so this reliably stops even "
+        "SUID-root processes inside it (which an in-container `timeout` cannot signal)."
+    ),
+)
 @click.argument("command", nargs=-1, default=("/bin/bash",))
-def run_command(challenge_path, user, volumes, cast_to, command):
+def run_command(challenge_path, user, volumes, cast_to, timeout, command):
     """Run interactive shell for a challenge."""
     try:
         image_id = lib.build_challenge(challenge_path)
@@ -49,29 +60,38 @@ def run_command(challenge_path, user, volumes, cast_to, command):
     logger.info("running %s as uid=%d, command=%s", challenge_path, user, list(command))
     with lib.run_challenge(challenge_path, image_id, volumes=resolved_volumes) as (container, flag):
         docker_command = ["docker", "exec", f"--user={user}", "-it", container, *command]
-        if cast_to is None:
-            subprocess.run(docker_command)
-        else:
-            if not shutil.which("asciinema"):
-                raise click.ClickException("--cast-to requires `asciinema` on PATH (it's in the nix dev shell).")
-            cols, rows = shutil.get_terminal_size((100, 30))
-            logger.info("recording session to %s", cast_to)
-            subprocess.run(
-                [
-                    "asciinema",
-                    "rec",
-                    "--command",
-                    shlex.join(docker_command),
-                    "--overwrite",
-                    "--quiet",
-                    "--cols",
-                    str(cols),
-                    "--rows",
-                    str(rows),
-                    "--title",
-                    f"{challenge_path.name} (pwnshop run)",
-                    str(cast_to),
-                ],
-                check=True,
-            )
-            click.echo(f"Session recorded to {cast_to}", err=True)
+        try:
+            if cast_to is None:
+                subprocess.run(docker_command, timeout=timeout)
+            else:
+                if not shutil.which("asciinema"):
+                    raise click.ClickException("--cast-to requires `asciinema` on PATH (it's in the nix dev shell).")
+                cols, rows = shutil.get_terminal_size((100, 30))
+                logger.info("recording session to %s", cast_to)
+                subprocess.run(
+                    [
+                        "asciinema",
+                        "rec",
+                        "--command",
+                        shlex.join(docker_command),
+                        "--overwrite",
+                        "--quiet",
+                        "--cols",
+                        str(cols),
+                        "--rows",
+                        str(rows),
+                        "--title",
+                        f"{challenge_path.name} (pwnshop run)",
+                        str(cast_to),
+                    ],
+                    check=True,
+                    timeout=timeout,
+                )
+                click.echo(f"Session recorded to {cast_to}", err=True)
+        except subprocess.TimeoutExpired as error:
+            # Leaving the `with` block tears the container down via the docker daemon,
+            # which kills every process inside it -- including SUID-root ones that a
+            # command running as `user` (or an in-container `timeout`) could never signal.
+            raise click.ClickException(
+                f"command did not finish within {timeout:g}s; aborting and tearing down the container"
+            ) from error


### PR DESCRIPTION
## Summary

A playtest cast in the discord-feedback bot hung for the full 600s watchdog and crashed the run with a `subprocess.TimeoutExpired` traceback. Root cause: the generated cast command ran `timeout 2 "$run_path" | tee …` against a **SUID-root** challenge process (the `ps` challenge prints the flag then `sleep 6h`). An unprivileged `timeout` cannot signal a root process, and the root `sleep` holds the pipe to `tee` open, so the command never returns. When the watchdog fired it `process.kill()`'d only the top process, so `pwnshop`'s container-teardown `finally` never ran — leaking the detached container with the root sleep still inside.

This fixes both the hang and the recovery, in two tools:

**`tools/pwnshop/src/pwnshop/commands/run.py` — durable prevention**
- New `--timeout SECONDS` on `pwnshop run`, bounding both plain and `--cast-to` sessions. On timeout it aborts and lets the existing `run_challenge` context manager tear the container down **via the docker daemon** — the only thing that can actually kill an in-container SUID-root process (an in-container `timeout`/`kill` cannot).

**`tools/feedback/discord-feedback` — graceful recovery**
- Casts now run with `pwnshop run --timeout 120` (`CAST_TIMEOUT_SECONDS`), with the outer `stream_command` watchdog as a `+60s` backstop, replacing the single blunt 600s.
- A wedged/failed/malformed cast no longer aborts the whole feedback run: `run_casts` records it to `casts/cast-failures.md` and continues (casts are a UX-review aid, not a gate).
- `stream_command` now starts children with `start_new_session=True` and a new `terminate_process_tree()` helper that SIGINT→SIGKILLs the whole process group (`nix → pwnshop → asciinema → docker`) instead of orphaning grandchildren. It also runs in the `finally`, so Ctrl-C / unexpected errors clean up too (no-op on the normal path).
- The playtest-plan prompt now forbids hang-prone commands at the source: the command runs unprivileged and must self-terminate, must not pipe from long-lived/SUID-root processes, must not rely on `timeout`/`kill` against privileged processes, and should mirror the real `tests_private` solve.

## Validation

- `pwnshop test challenges/linux-luminarium/processes/ps` — passes (also confirms the `run.py` change doesn't break the CLI).
- Reproduced the exact hang (`timeout 2 "$run_path" | tee` against the SUID-root `ps` process) under `pwnshop run --cast-to … --timeout 15`: aborted at the limit (`command did not finish within 15s; aborting and tearing down the container`, exit 1, ~19s wall) with container count unchanged before/after — no leak.
- `run.py` is ruff-clean at the configured `--line-length 120`; `discord-feedback` is extensionless so treefmt skips it.

## Notes

- This is tooling only; no challenge content changes.