### PR TITLE
discord-feedback: stop PR-reply failures from crashing the watcher

### DIFF
--- a/tools/feedback/discord-feedback
+++ b/tools/feedback/discord-feedback
@@ -1921,13 +1921,17 @@ def post_issue_comment(
 def clear_pending_review(
     api: GitHubAPI, owner: str, repo_name: str, pull_number: int
 ) -> bool:
-    """Delete the token user's leftover PENDING (draft) review on the PR.
+    """Delete the token user's leftover *empty* PENDING (draft) review on the PR.
 
     GitHub rejects a review-comment reply with 422 "user_id can only have one pending
     review per pull request" when the authenticated user has a stale draft review (left
-    behind by an interrupted run). Deleting that draft unblocks replies. Only the
-    authenticated user's own pending review is listed/deletable here, and only drafts
-    (state == "PENDING") are touched -- never a submitted review.
+    behind by an interrupted run). Deleting that draft unblocks replies.
+
+    Guards against destroying real work: only the authenticated user's own drafts
+    (state == "PENDING") are considered, and only ones that are *empty* -- no body and no
+    draft comments -- are deleted. A maintainer running this bot with their own PAT may
+    have a genuine review in progress on the same PR; a non-empty draft is left untouched
+    (the reply just stays unposted) rather than discarding their unsubmitted work.
     """
     me = api.authenticated_login()
     if not me:
@@ -1941,20 +1945,48 @@ def clear_pending_review(
         return False
     cleared = False
     for review in reviews:
+        review_id = review.get("id")
         if review.get("state") != "PENDING":
             continue
         if (review.get("user") or {}).get("login") != me:
             continue
+        if (review.get("body") or "").strip():
+            logger.warning(
+                "leaving non-empty pending review %s on PR #%s in place",
+                review_id,
+                pull_number,
+            )
+            continue
+        try:
+            draft_comments = api.request_all(
+                f"/repos/{owner}/{repo_name}/pulls/{pull_number}/reviews/{review_id}/comments"
+            )
+        except GitHubAPIError as error:
+            logger.warning(
+                "could not inspect pending review %s on PR #%s (%s); leaving it in place",
+                review_id,
+                pull_number,
+                error,
+            )
+            continue
+        if draft_comments:
+            logger.warning(
+                "leaving pending review %s with %d draft comment(s) on PR #%s in place",
+                review_id,
+                len(draft_comments),
+                pull_number,
+            )
+            continue
         try:
             api.delete(
-                f"/repos/{owner}/{repo_name}/pulls/{pull_number}/reviews/{review['id']}"
+                f"/repos/{owner}/{repo_name}/pulls/{pull_number}/reviews/{review_id}"
             )
             cleared = True
-            click.echo(f"Cleared a stale pending review on PR #{pull_number}")
+            click.echo(f"Cleared an empty stale pending review on PR #{pull_number}")
         except GitHubAPIError as error:
             logger.warning(
                 "could not delete pending review %s on PR #%s: %s",
-                review.get("id"),
+                review_id,
                 pull_number,
                 error,
             )
@@ -2605,13 +2637,19 @@ def post_pending_pr_feedback_replies(
         try:
             post_pr_event_reply(api, owner, repo_name, pr_number, event, body)
         except GitHubAPIError as error:
-            # Posting a reply must never crash the watcher. The deterministic causes
-            # (stale draft review -> 422, deleted comment -> 404) won't succeed on retry,
-            # so record the key as handled and move on instead of looping or aborting.
+            # Posting a reply must never crash the watcher. Distinguish permanent failures
+            # -- a deleted comment (404) or a validation rejection (422) that retrying
+            # can't fix -- from transient ones (5xx, secondary-rate-limit 403, network).
+            # Only permanent failures are recorded as handled; transient ones are left
+            # unreplied so the next loop retries instead of silently dropping the reply.
+            permanent = error.status in (404, 422)
+            disposition = "recording it as handled" if permanent else "will retry next loop"
             click.echo(
-                f"Could not post automated GitHub reply for {key}: {error}; skipping it"
+                f"Could not post automated GitHub reply for {key}: {error}; {disposition}"
             )
             logger.warning("failed to post PR reply for %s: %s", key, error)
+            if not permanent:
+                continue
         replied.add(key)
         state["replied_events"] = sorted(replied)
         save_watch_state(state_path, state)

--- a/tools/feedback/discord-feedback
+++ b/tools/feedback/discord-feedback
@@ -89,7 +89,9 @@ class DiscordServerError(RuntimeError):
 
 
 class GitHubAPIError(RuntimeError):
-    pass
+    def __init__(self, message: str, *, status: Optional[int] = None) -> None:
+        super().__init__(message)
+        self.status = status
 
 
 class GitHubNotFound(GitHubAPIError):
@@ -195,6 +197,7 @@ class DiscordAPI:
 class GitHubAPI:
     def __init__(self, token: str):
         self.token = token
+        self._login: Optional[str] = None
 
     @classmethod
     def from_environment(cls, repo: pathlib.Path) -> "GitHubAPI":
@@ -234,6 +237,26 @@ class GitHubAPI:
             path, accept=accept, method="POST", json_body=payload
         )
         return response
+
+    def delete(
+        self,
+        path: str,
+        *,
+        accept: str = "application/vnd.github+json",
+    ) -> Any:
+        response, _headers = self._request(path, accept=accept, method="DELETE")
+        return response
+
+    def authenticated_login(self) -> Optional[str]:
+        """Login of the token's user, cached. None if it can't be determined."""
+        if self._login is None:
+            try:
+                user = self.request("/user")
+                self._login = (user or {}).get("login") or ""
+            except GitHubAPIError as error:
+                logger.warning("could not determine authenticated GitHub user: %s", error)
+                self._login = ""
+        return self._login or None
 
     def request_all(
         self,
@@ -303,9 +326,10 @@ class GitHubAPI:
         except urllib.error.HTTPError as error:
             body = error.read().decode(errors="replace")
             if error.code == 404:
-                raise GitHubNotFound(f"404 for {url}") from error
+                raise GitHubNotFound(f"404 for {url}", status=404) from error
             raise GitHubAPIError(
-                f"GitHub API request failed: {error.code} {url}: {body}"
+                f"GitHub API request failed: {error.code} {url}: {body}",
+                status=error.code,
             ) from error
 
 
@@ -1894,6 +1918,49 @@ def post_issue_comment(
     )
 
 
+def clear_pending_review(
+    api: GitHubAPI, owner: str, repo_name: str, pull_number: int
+) -> bool:
+    """Delete the token user's leftover PENDING (draft) review on the PR.
+
+    GitHub rejects a review-comment reply with 422 "user_id can only have one pending
+    review per pull request" when the authenticated user has a stale draft review (left
+    behind by an interrupted run). Deleting that draft unblocks replies. Only the
+    authenticated user's own pending review is listed/deletable here, and only drafts
+    (state == "PENDING") are touched -- never a submitted review.
+    """
+    me = api.authenticated_login()
+    if not me:
+        return False
+    try:
+        reviews = api.request_all(
+            f"/repos/{owner}/{repo_name}/pulls/{pull_number}/reviews"
+        )
+    except GitHubAPIError as error:
+        logger.warning("could not list reviews on PR #%s: %s", pull_number, error)
+        return False
+    cleared = False
+    for review in reviews:
+        if review.get("state") != "PENDING":
+            continue
+        if (review.get("user") or {}).get("login") != me:
+            continue
+        try:
+            api.delete(
+                f"/repos/{owner}/{repo_name}/pulls/{pull_number}/reviews/{review['id']}"
+            )
+            cleared = True
+            click.echo(f"Cleared a stale pending review on PR #{pull_number}")
+        except GitHubAPIError as error:
+            logger.warning(
+                "could not delete pending review %s on PR #%s: %s",
+                review.get("id"),
+                pull_number,
+                error,
+            )
+    return cleared
+
+
 def post_review_comment_reply(
     api: GitHubAPI,
     owner: str,
@@ -1902,10 +1969,18 @@ def post_review_comment_reply(
     comment_id: int,
     body: str,
 ) -> None:
-    api.post(
-        f"/repos/{owner}/{repo_name}/pulls/{pull_number}/comments/{comment_id}/replies",
-        {"body": with_automation_notice(body)},
-    )
+    path = f"/repos/{owner}/{repo_name}/pulls/{pull_number}/comments/{comment_id}/replies"
+    payload = {"body": with_automation_notice(body)}
+    try:
+        api.post(path, payload)
+    except GitHubAPIError as error:
+        # A stale draft review blocks replies with 422; clear it and retry once.
+        if error.status == 422 and clear_pending_review(
+            api, owner, repo_name, pull_number
+        ):
+            api.post(path, payload)
+        else:
+            raise
 
 
 def event_time(item: dict[str, Any]) -> str:
@@ -2527,11 +2602,20 @@ def post_pending_pr_feedback_replies(
             response.get("commit"),
             bool(response.get("pushed")),
         )
-        post_pr_event_reply(api, owner, repo_name, pr_number, event, body)
+        try:
+            post_pr_event_reply(api, owner, repo_name, pr_number, event, body)
+        except GitHubAPIError as error:
+            # Posting a reply must never crash the watcher. The deterministic causes
+            # (stale draft review -> 422, deleted comment -> 404) won't succeed on retry,
+            # so record the key as handled and move on instead of looping or aborting.
+            click.echo(
+                f"Could not post automated GitHub reply for {key}: {error}; skipping it"
+            )
+            logger.warning("failed to post PR reply for %s: %s", key, error)
         replied.add(key)
         state["replied_events"] = sorted(replied)
         save_watch_state(state_path, state)
-        click.echo(f"Posted automated GitHub reply for {key}")
+        click.echo(f"Recorded automated GitHub reply state for {key}")
 
 
 def next_watch_batch(state: dict[str, Any]) -> int:


### PR DESCRIPTION
## Summary

The feedback bot crashed (uncaught `GitHubAPIError`) while posting a PR review-comment reply:

```
422 .../pulls/220/comments/3426053176/replies:
{"resource":"PullRequestReview","field":"user_id",
 "message":"user_id can only have one pending review per pull request"}
```

Root cause: an interrupted earlier run left a **stale draft (PENDING) review** on the PR owned by the bot's token (`zardus`). While a draft review exists, GitHub rejects every review-comment reply with that 422, and the error propagated out of `watch_pull_request` → killed the whole bot. (Confirmed live: PR #220 had an empty PENDING review by `zardus`; deleting it unblocked replies.)

Two-part fix, both in `tools/feedback/discord-feedback`:

- **Self-heal the root cause.** `GitHubAPIError` now carries the HTTP `status`. On a 422 from the replies endpoint, `clear_pending_review()` deletes the token user's *own* stale draft review (drafts only — `state == "PENDING"`, never a submitted review) and retries the reply once. Adds `GitHubAPI.delete()` and `GitHubAPI.authenticated_login()` (cached `GET /user`).
- **Never crash the watcher.** `post_pending_pr_feedback_replies` now wraps each reply post: any `GitHubAPIError` is logged and the event is recorded as handled, so a permanently-failing reply (deleted comment → 404, unresolved 422) is skipped instead of aborting the run or re-spamming every loop.

## Validation

- `python -m py_compile` clean; new symbols present. `discord-feedback` is extensionless so treefmt/ruff skips it.
- Live diagnosis confirmed: token user is `zardus`; PR #220 had a PENDING review by `zardus` (empty body) blocking replies. Deleting it (the exact call `clear_pending_review` makes) removed the blocker — PR #220 now has only the Codex bot's submitted review.

## Notes

- Tooling only; no challenge content changes.
- Follow-up to #219 (same "harden the feedback bot" effort).