### PR TITLE
Address challenge feedback from Discord

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -48,6 +48,48 @@ When adding a dojo that needs encrypted tests or maintainer access, update `main
 Each challenge still builds as its own image from its rendered `/challenge` directory.
 Shared Dockerfiles and packages reuse Docker's layer cache, so the monorepo does not require one giant image per dojo.
 
+## Known Production Parity Constraints
+
+`pwnshop run` and `pwnshop test` use the local challenge runtime to approximate production, but privileged container behavior can still differ from deployed challenges.
+Treat production as the source of truth for kernel-global state and host-provided networking features.
+
+Production exposes `/proc/sys` read-only to challenge containers.
+Do not rely on a local privileged run that can write `/proc/sys`, and do not let `.init` scripts ignore a failed `sysctl -w`.
+Use `set -euo pipefail` in bash `.init` scripts, or `set -eu` in POSIX `sh`, and add an explicit post-check when the setting matters:
+
+```bash
+sysctl -w net.ipv4.ip_forward=1
+test "$(cat /proc/sys/net/ipv4/ip_forward)" = 1
+```
+
+The shared Ubuntu challenge base in `challenges/common/Dockerfile.j2` installs only the default Python/web packages unless a challenge adds more packages.
+It does not provide `iptables`, `iptables-legacy`, or `nft` by default.
+If a challenge needs firewall rules, add the needed package in the challenge Dockerfile and prefer `iptables-legacy` over `nft`, since production does not provide nftables.
+Check the exact binary in the built challenge:
+
+```bash
+./pwnshop run --user 0 challenges/MODULE/CHALLENGE /bin/sh -lc 'command -v iptables-legacy && ! command -v nft'
+```
+
+Failed `/challenge/.init` output is surfaced by `pwnshop`, so a minimal smoke check for init diagnostics is:
+
+```bash
+tmp="$(mktemp -d challenges/.runtime-smoke.XXXXXX)"
+trap 'rm -rf "$tmp"' EXIT
+mkdir -p "$tmp/challenge"
+cat > "$tmp/challenge/Dockerfile.j2" <<'EOF'
+FROM ubuntu:24.04
+COPY . /challenge
+EOF
+cat > "$tmp/challenge/.init" <<'EOF'
+#!/bin/sh
+echo "visible init failure" >&2
+exit 42
+EOF
+chmod +x "$tmp/challenge/.init"
+./pwnshop run "$tmp" /bin/true
+```
+
 ## Troubleshooting
 
 `nix develop` prompts for sudo every time:

--- a/tools/pwnshop/src/pwnshop/commands/run.py
+++ b/tools/pwnshop/src/pwnshop/commands/run.py
@@ -66,7 +66,9 @@ def run_command(challenge_path, user, volumes, cast_to, timeout, command):
                     subprocess.run(docker_command, timeout=timeout)
                 else:
                     if not shutil.which("asciinema"):
-                        raise click.ClickException("--cast-to requires `asciinema` on PATH (it's in the nix dev shell).")
+                        raise click.ClickException(
+                            "--cast-to requires `asciinema` on PATH (it's in the nix dev shell)."
+                        )
                     cols, rows = shutil.get_terminal_size((100, 30))
                     logger.info("recording session to %s", cast_to)
                     subprocess.run(

--- a/tools/pwnshop/src/pwnshop/commands/run.py
+++ b/tools/pwnshop/src/pwnshop/commands/run.py
@@ -58,40 +58,43 @@ def run_command(challenge_path, user, volumes, cast_to, timeout, command):
         raise click.ClickException(str(error)) from error
     resolved_volumes = [path.resolve() for path in volumes]
     logger.info("running %s as uid=%d, command=%s", challenge_path, user, list(command))
-    with lib.run_challenge(challenge_path, image_id, volumes=resolved_volumes) as (container, flag):
-        docker_command = ["docker", "exec", f"--user={user}", "-it", container, *command]
-        try:
-            if cast_to is None:
-                subprocess.run(docker_command, timeout=timeout)
-            else:
-                if not shutil.which("asciinema"):
-                    raise click.ClickException("--cast-to requires `asciinema` on PATH (it's in the nix dev shell).")
-                cols, rows = shutil.get_terminal_size((100, 30))
-                logger.info("recording session to %s", cast_to)
-                subprocess.run(
-                    [
-                        "asciinema",
-                        "rec",
-                        "--command",
-                        shlex.join(docker_command),
-                        "--overwrite",
-                        "--quiet",
-                        "--cols",
-                        str(cols),
-                        "--rows",
-                        str(rows),
-                        "--title",
-                        f"{challenge_path.name} (pwnshop run)",
-                        str(cast_to),
-                    ],
-                    check=True,
-                    timeout=timeout,
-                )
-                click.echo(f"Session recorded to {cast_to}", err=True)
-        except subprocess.TimeoutExpired as error:
-            # Leaving the `with` block tears the container down via the docker daemon,
-            # which kills every process inside it -- including SUID-root ones that a
-            # command running as `user` (or an in-container `timeout`) could never signal.
-            raise click.ClickException(
-                f"command did not finish within {timeout:g}s; aborting and tearing down the container"
-            ) from error
+    try:
+        with lib.run_challenge(challenge_path, image_id, volumes=resolved_volumes) as (container, flag):
+            docker_command = ["docker", "exec", f"--user={user}", "-it", container, *command]
+            try:
+                if cast_to is None:
+                    subprocess.run(docker_command, timeout=timeout)
+                else:
+                    if not shutil.which("asciinema"):
+                        raise click.ClickException("--cast-to requires `asciinema` on PATH (it's in the nix dev shell).")
+                    cols, rows = shutil.get_terminal_size((100, 30))
+                    logger.info("recording session to %s", cast_to)
+                    subprocess.run(
+                        [
+                            "asciinema",
+                            "rec",
+                            "--command",
+                            shlex.join(docker_command),
+                            "--overwrite",
+                            "--quiet",
+                            "--cols",
+                            str(cols),
+                            "--rows",
+                            str(rows),
+                            "--title",
+                            f"{challenge_path.name} (pwnshop run)",
+                            str(cast_to),
+                        ],
+                        check=True,
+                        timeout=timeout,
+                    )
+                    click.echo(f"Session recorded to {cast_to}", err=True)
+            except subprocess.TimeoutExpired as error:
+                # Leaving the `with` block tears the container down via the docker daemon,
+                # which kills every process inside it -- including SUID-root ones that a
+                # command running as `user` (or an in-container `timeout`) could never signal.
+                raise click.ClickException(
+                    f"command did not finish within {timeout:g}s; aborting and tearing down the container"
+                ) from error
+    except RuntimeError as error:
+        raise click.ClickException(str(error)) from error

--- a/tools/pwnshop/src/pwnshop/lib/__init__.py
+++ b/tools/pwnshop/src/pwnshop/lib/__init__.py
@@ -146,48 +146,48 @@ def run_challenge(
         .strip()
     )
     logger.debug("container started: %s", container[:12])
-    subprocess.run(
-        [
-            "docker",
-            "exec",
-            "--interactive",
-            "--user=0:0",
-            container,
-            "/bin/sh",
-            "-c",
-            "cat >/flag && chown 0:0 /flag && chmod 0400 /flag",
-        ],
-        input=f"{flag}\n",
-        text=True,
-        check=True,
-    )
-    logger.debug("flag written to /flag")
     try:
         subprocess.run(
             [
                 "docker",
                 "exec",
+                "--interactive",
                 "--user=0:0",
                 container,
                 "/bin/sh",
                 "-c",
-                INIT_SCRIPT,
+                "cat >/flag && chown 0:0 /flag && chmod 0400 /flag",
             ],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
+            input=f"{flag}\n",
             text=True,
             check=True,
         )
-    except subprocess.CalledProcessError as error:
-        output = (error.stdout or "").rstrip()
-        message = f"Failed to initialize {challenge_path} with /challenge/.init (exit code {error.returncode})."
-        if output:
-            message = f"{message}\n{output}"
-        else:
-            message = f"{message}\n/challenge/.init produced no output."
-        raise RuntimeError(message) from error
-    logger.debug(".init completed (if present)")
-    try:
+        logger.debug("flag written to /flag")
+        try:
+            subprocess.run(
+                [
+                    "docker",
+                    "exec",
+                    "--user=0:0",
+                    container,
+                    "/bin/sh",
+                    "-c",
+                    INIT_SCRIPT,
+                ],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+                check=True,
+            )
+        except subprocess.CalledProcessError as error:
+            output = (error.stdout or "").rstrip()
+            message = f"Failed to initialize {challenge_path} with /challenge/.init (exit code {error.returncode})."
+            if output:
+                message = f"{message}\n{output}"
+            else:
+                message = f"{message}\n/challenge/.init produced no output."
+            raise RuntimeError(message) from error
+        logger.debug(".init completed (if present)")
         yield container, flag
     finally:
         logger.debug("killing container %s", container[:12])

--- a/tools/pwnshop/src/pwnshop/lib/__init__.py
+++ b/tools/pwnshop/src/pwnshop/lib/__init__.py
@@ -18,6 +18,19 @@ import yaml
 logger = logging.getLogger(__name__)
 
 CHALLENGE_SEED = int(os.environ.get("CHALLENGE_SEED", "0"))
+INIT_SCRIPT = r"""
+if [ -e /challenge/.init ]; then
+    init_log="$(mktemp)"
+    /challenge/.init >"$init_log" 2>&1
+    init_status=$?
+    if [ "$init_status" -ne 0 ]; then
+        cat "$init_log"
+        rm -f "$init_log"
+        exit "$init_status"
+    fi
+    rm -f "$init_log"
+fi
+"""
 
 clang_format = shutil.which("clang-format")
 if not clang_format:
@@ -149,20 +162,30 @@ def run_challenge(
         check=True,
     )
     logger.debug("flag written to /flag")
-    subprocess.run(
-        [
-            "docker",
-            "exec",
-            "--user=0:0",
-            container,
-            "/bin/sh",
-            "-c",
-            "[ ! -e /challenge/.init ] || /challenge/.init",
-        ],
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
-        check=True,
-    )
+    try:
+        subprocess.run(
+            [
+                "docker",
+                "exec",
+                "--user=0:0",
+                container,
+                "/bin/sh",
+                "-c",
+                INIT_SCRIPT,
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            check=True,
+        )
+    except subprocess.CalledProcessError as error:
+        output = (error.stdout or "").rstrip()
+        message = f"Failed to initialize {challenge_path} with /challenge/.init (exit code {error.returncode})."
+        if output:
+            message = f"{message}\n{output}"
+        else:
+            message = f"{message}\n/challenge/.init produced no output."
+        raise RuntimeError(message) from error
     logger.debug(".init completed (if present)")
     try:
         yield container, flag


### PR DESCRIPTION
THIS MESSAGE IS GENERATED BY AN AUTOMATED PROCESS.

## Summary
- Addressed feedback from sanitized public Discord messages about local `pwnshop run` hiding production-parity problems for privileged challenges.
- Updated `docs/development.md` to document production constraints around read-only `/proc/sys`, missing default firewall tooling, preferring `iptables-legacy` over `nft`, and making `.init` scripts fail loudly.
- Updated `tools/pwnshop/src/pwnshop/lib/__init__.py` so failed `/challenge/.init` output is captured and surfaced instead of discarded.
- Updated `tools/pwnshop/src/pwnshop/commands/run.py` so init setup failures are reported as normal CLI errors instead of Python tracebacks.
- No challenge or module content was changed.

## Validation
- Ran `python -m compileall tools/pwnshop/src/pwnshop`.
- Ran a `nix develop --command` smoke check with a temporary challenge whose `.init` prints `visible init failure` and exits `42`; verified the output appears and no traceback appears.
- Attempted the feedback-run `pwnshop test` path; it reported `No challenges found since origin/main`, so no challenge tests were run.

## Notes / deferred follow-ups
- CIMG/reversing bridge and Android feedback were not changed here because the inputs did not identify a reviewable active non-legacy module path, and this run was constrained not to touch `./legacy`, `linux-luminarium` destruction content, or `advent-of-pwn`.
