### PR TITLE
runtime: fix PATH

### DIFF
--- a/runtime/workspace/agent/cmd/workspace-entrypoint/main.go
+++ b/runtime/workspace/agent/cmd/workspace-entrypoint/main.go
@@ -16,7 +16,11 @@ import (
 
 const agentUID = 1000
 const agentGID = 1000
+const challengeBin = "/challenge/bin"
+const challengeRunDir = "/run/challenge"
+const challengeRunBin = "/run/challenge/bin"
 const workspaceRunDir = "/run/workspace"
+const workspaceProfile = "/run/workspace/profile"
 const workspaceUserRunDir = "/run/workspace/user"
 const workspaceServicesDir = "/run/workspace/user/services"
 
@@ -142,11 +146,13 @@ func prepareWorkspace(config workspaceConfig) error {
 }
 
 func setupRunDirectories() error {
-	if err := os.MkdirAll(workspaceRunDir, 0755); err != nil {
-		return err
-	}
-	if err := os.Chmod(workspaceRunDir, 0755); err != nil {
-		return err
+	for _, directory := range []string{challengeRunDir, workspaceRunDir} {
+		if err := os.MkdirAll(directory, 0755); err != nil {
+			return err
+		}
+		if err := os.Chmod(directory, 0755); err != nil {
+			return err
+		}
 	}
 	for _, directory := range []string{workspaceUserRunDir, workspaceServicesDir} {
 		if err := os.MkdirAll(directory, 0700); err != nil {
@@ -159,7 +165,47 @@ func setupRunDirectories() error {
 			return err
 		}
 	}
+	if err := linkChallengeBin(); err != nil {
+		return err
+	}
+	if err := linkWorkspaceProfile(); err != nil {
+		return err
+	}
 	return linkServiceDefinitions()
+}
+
+func linkChallengeBin() error {
+	if _, err := os.Stat(challengeBin); errors.Is(err, os.ErrNotExist) {
+		return nil
+	} else if err != nil {
+		return err
+	}
+	if err := os.Remove(challengeRunBin); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	return os.Symlink(challengeBin, challengeRunBin)
+}
+
+func linkWorkspaceProfile() error {
+	target, err := workspaceProfileTarget()
+	if err != nil {
+		return err
+	}
+	if err := os.Remove(workspaceProfile); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	return os.Symlink(target, workspaceProfile)
+}
+
+func workspaceProfileTarget() (string, error) {
+	if len(os.Args) > 0 && filepath.IsAbs(os.Args[0]) {
+		return filepath.Clean(filepath.Join(filepath.Dir(os.Args[0]), "..")), nil
+	}
+	executable, err := os.Executable()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Clean(filepath.Join(filepath.Dir(executable), "..")), nil
 }
 
 func runChallengeInit() error {
@@ -306,27 +352,11 @@ func linkServiceDefinitions() error {
 }
 
 func serviceDefinitionsDir() (string, error) {
-	candidates := make([]string, 0, 3)
-	if workspace := os.Getenv("PWN_WORKSPACE"); workspace != "" {
-		candidates = append(candidates, filepath.Join(workspace, "share", "workspace", "services"))
-	}
-	if len(os.Args) > 0 && filepath.IsAbs(os.Args[0]) {
-		candidates = append(candidates, filepath.Join(filepath.Dir(os.Args[0]), "..", "share", "workspace", "services"))
-	}
-	executable, err := os.Executable()
-	if err != nil {
+	directory := filepath.Join(workspaceProfile, "share", "workspace", "services")
+	if _, err := os.Stat(directory); err != nil {
 		return "", err
 	}
-	candidates = append(candidates, filepath.Join(filepath.Dir(executable), "..", "share", "workspace", "services"))
-
-	for _, candidate := range candidates {
-		if _, err := os.Stat(candidate); err == nil {
-			return candidate, nil
-		} else if !errors.Is(err, os.ErrNotExist) {
-			return "", err
-		}
-	}
-	return "", fmt.Errorf("workspace service definitions not found in %v", candidates)
+	return directory, nil
 }
 
 func writeFlag(flag string) error {

--- a/tools/pwnshop/src/pwnshop/lib/__init__.py
+++ b/tools/pwnshop/src/pwnshop/lib/__init__.py
@@ -1,5 +1,6 @@
 import base64
 import contextlib
+import json
 import logging
 import os
 import pathlib
@@ -85,6 +86,20 @@ def render_challenge(template_directory: pathlib.Path) -> pathlib.Path:
     return rendered_directory
 
 
+def image_path(challenge_image: str) -> str:
+    image_env = json.loads(
+        subprocess.check_output(
+            ["docker", "image", "inspect", "--format={{json .Config.Env}}", challenge_image],
+            text=True,
+        )
+    )
+    for entry in image_env or []:
+        name, separator, value = entry.partition("=")
+        if separator and name == "PATH":
+            return value
+    return ""
+
+
 @contextlib.contextmanager
 def run_challenge(
     challenge_path: pathlib.Path,
@@ -115,6 +130,9 @@ def run_challenge(
     logger.debug("container runtime options for %s: %s", challenge_path, runtime_options)
     if volumes:
         logger.debug("mounting volumes: %s", volumes)
+    container_path = ":".join(
+        path for path in ["/run/challenge/bin", "/run/workspace/profile/bin", image_path(challenge_image)] if path
+    )
     container = None
     try:
         container = subprocess.check_output(
@@ -125,8 +143,7 @@ def run_challenge(
                 "--user=0:0",
                 f"--env=PWN_FLAG={flag}",
                 "--env=PWN_USER=hacker",
-                f"--env=PWN_WORKSPACE={workspace}",
-                f"--env=PATH={workspace}/bin:/challenge/bin:/run/workspace/bin:/run/dojo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+                f"--env=PATH={container_path}",
                 "--volume=/nix:/nix:ro",
                 *runtime_options,
                 *[f"--volume={volume}:{volume}:ro" for volume in (volumes or [])],


### PR DESCRIPTION
## Summary
- prepend stable challenge/workspace runtime paths to the image PATH
- derive /run/workspace/profile from the entrypoint path instead of passing PWN_WORKSPACE into containers
- expose /run/challenge/bin when /challenge/bin exists

## Tests
- nix build .#pwn-workspace-runtime
- pwnshop run smoke check for PATH/profile links