### PR TITLE
runtime: fix ttyd font

### DIFF
--- a/runtime/workspace/services/tty/default.nix
+++ b/runtime/workspace/services/tty/default.nix
@@ -16,13 +16,18 @@ let
 
         {
           printf '<style>\n'
-          printf '@font-face{font-family:"DejaVu Sans Mono";src:url(data:font/ttf;base64,'
-          base64 -w0 ${pkgs.dejavu_fonts}/share/fonts/truetype/DejaVuSansMono.ttf
-          printf ') format("truetype");font-weight:400;font-style:normal;font-display:block;}\n'
+          printf '@font-face{font-family:"JetBrains Mono";src:url(data:font/woff2;base64,'
+          base64 -w0 ${pkgs.jetbrains-mono}/share/fonts/WOFF2/JetBrainsMono-Regular.woff2
+          printf ') format("woff2");font-weight:400;font-style:normal;font-display:block;}\n'
           printf '</style>\n'
+          printf '<script>\n'
+          printf 'window.__workspaceReadyTerminalFont=function(){if(!document.fonts)return Promise.resolve();var font=Promise.all([document.fonts.load('"'"'13px "JetBrains Mono"'"'"'),document.fonts.ready]);var timeout=new Promise(function(resolve){setTimeout(resolve,1000)});return Promise.race([font,timeout]).catch(function(){})};\n'
+          printf '</script>\n'
         } > font.html
 
         perl -0pi -e 'open my $fh, "<", "font.html" or die $!; local $/; my $font = <$fh>; s#</head>#$font</head>#' index.html
+        perl -0pi -e 's#fontFamily:"Consolas,Liberation Mono,Menlo,Courier,monospace"#fontFamily:"\\"JetBrains Mono\\", monospace"#' index.html
+        perl -0pi -e 's#\Q(0,e.render)((0,e.h)(t.App,null),document.body)\E#(window.__workspaceReadyTerminalFont?window.__workspaceReadyTerminalFont():Promise.resolve()).then(function(){(0,e.render)((0,e.h)(t.App,null),document.body)})#' index.html
 
         mkdir -p $out/share/workspace/ttyd
         cp index.html $out/share/workspace/ttyd/index.html
@@ -40,7 +45,6 @@ let
         --writable \
         -t disableLeaveAlert=true \
         -t disableResizeOverlay=true \
-        -t 'fontFamily="DejaVu Sans Mono", monospace' \
         --cwd "$HOME" \
         "$SHELL" \
         --login


### PR DESCRIPTION
## Summary
- switch ttyd to embedded JetBrains Mono
- set the font in ttyd's initial xterm options instead of sending fontFamily over client options
- wait for the webfont before rendering ttyd to avoid bad initial glyph spacing

## Tests
- nix build .#pwn-workspace-runtime
- generated ttyd JavaScript parsed with node --check