### PR TITLE
discord-feedback: --resume-latest skips abandoned/empty runs

### DIFF
--- a/tools/feedback/discord-feedback
+++ b/tools/feedback/discord-feedback
@@ -3183,11 +3183,34 @@ def existing_pr_url(repo: pathlib.Path) -> Optional[str]:
     return result.stdout.strip() or None
 
 
+def _run_has_progress(run_dir: pathlib.Path) -> bool:
+    """A run is worth resuming if it got past its scrape -- i.e. it opened a PR or
+    checkpointed at least one phase. A bare directory with neither is an abandoned/botched
+    start (e.g. a mistyped fresh run), and --resume-latest must skip past it rather than
+    re-scrape from scratch."""
+    if (run_dir / "pr-url.txt").exists():
+        return True
+    try:
+        state = json.loads((run_dir / "resume-state.json").read_text())
+    except (OSError, ValueError):
+        return False
+    return bool(state.get("completed_phases"))
+
+
 def latest_run_id(artifact_root_dir: pathlib.Path) -> Optional[str]:
     if not artifact_root_dir.is_dir():
         return None
-    runs = sorted(p.name for p in artifact_root_dir.iterdir() if p.is_dir())
-    return runs[-1] if runs else None
+    runs = sorted(
+        (p for p in artifact_root_dir.iterdir() if p.is_dir()), key=lambda p: p.name
+    )
+    if not runs:
+        return None
+    # Prefer the newest run with actual resumable progress; only if none qualifies do we
+    # fall back to the newest directory (preserving the old behavior for first-time resumes).
+    for run in reversed(runs):
+        if _run_has_progress(run):
+            return run.name
+    return runs[-1].name
 
 
 @click.command("discord-feedback")


### PR DESCRIPTION
## Problem

`--resume-latest` took the newest run directory unconditionally. If a fresh run is mistyped — e.g. `--directions --resume-latest`, where `--directions` swallows `--resume-latest` as its value and the bot starts a brand-new run, creating an empty run dir — that empty dir then shadows the real resumable run. `--resume-latest` resumes the empty one and **re-scrapes Discord from scratch** instead of continuing the run you meant.

This bit a real session: an empty `20260623-085416` shadowed `20260623-011610` (which had opened PR #238 and completed every phase).

## Fix

`latest_run_id` now prefers the newest run with actual resumable progress — one that opened a PR (`pr-url.txt`) or checkpointed at least one phase in `resume-state.json` — and only falls back to the newest directory when none qualifies (preserving first-time-resume behavior).

Verified against the live artifact dir: with the empty `20260623-085416` present, `latest_run_id` now returns `20260623-011610` (the run that made PR #238).

🤖 Generated with [Claude Code](https://claude.com/claude-code)