### PR TITLE
discord-feedback: don't require the Discord token when resume skips scraping

### DIFF
--- a/tools/feedback/discord-feedback
+++ b/tools/feedback/discord-feedback
@@ -3389,11 +3389,10 @@ def feedback_command(
         raise click.ClickException("--create-pr requires --apply.")
     if create_pr and skip_tests:
         raise click.ClickException("--create-pr cannot be combined with --skip-tests.")
+    # The Discord token is only needed to scrape. A resume that skips the scrape (notably the
+    # fast-path that re-attaches to an already-opened PR) must not require it -- otherwise a
+    # fresh shell without the token can't even resume a watch. Validated at point-of-use below.
     token = os.environ.get(token_env)
-    if not token:
-        raise click.ClickException(
-            f"{token_env} is not set. Create a Discord bot token and export it first."
-        )
     resuming = bool(resume_run_id) or resume_latest
     if resume_run_id and resume_latest:
         raise click.ClickException("Use either --resume or --resume-latest, not both.")
@@ -3486,6 +3485,10 @@ def feedback_command(
     until = utc_now()
     since = resolve_scrape_since(repo, until, hours, DEFAULT_FALLBACK_HOURS)
 
+    if not token:
+        raise click.ClickException(
+            f"{token_env} is not set. Create a Discord bot token and export it first."
+        )
     api = DiscordAPI(token)
     click.echo(f"Scraping Discord messages since {since.isoformat()} into {artifact_dir}")
     channels, channels_by_id = discover_channels(


### PR DESCRIPTION
## Problem

The Discord bot token was validated unconditionally at startup — before the resume fast-path that re-attaches to an already-opened PR and only watches it. That fast-path never touches Discord, so resuming a watch from a fresh shell without the token (e.g. a new `screen` window after the session was lost) died immediately:

```
Error: DISCORD_BOT_TOKEN is not set. Create a Discord bot token and export it first.
```

…despite needing no Discord access at all.

## Fix

Move the token requirement to point-of-use, right before the scrape. Resumes that skip the scrape (the create-pr fast-path) now run tokenless; a real scrape still fails fast with the same clear message. GitHub auth already falls back to `gh auth token`, so a watch-only resume needs no exported secrets.

Verified live: a fresh screen window with no `DISCORD_BOT_TOKEN` now resumes straight into watching PR #238.

🤖 Generated with [Claude Code](https://claude.com/claude-code)