### PR TITLE
ci: fix challenge image publish build command

### DIFF
--- a/.github/workflows/publish-challenges.yml
+++ b/.github/workflows/publish-challenges.yml
@@ -84,7 +84,7 @@ jobs:
           sudo mkdir -p "$publish_manifests_dir/$challenge_slug"
           printf '%s\n' "$image_id" | sudo tee "$publish_manifests_dir/$challenge_slug/latest" >/dev/null
         done < <(
-          docker image ls --filter "label=pwncollege.challenge" --no-trunc --quiet \
+          docker image ls --all --filter "label=pwncollege.challenge" --no-trunc --quiet \
             | xargs -r docker image inspect --format '{{.Id}} {{index .Config.Labels "pwncollege.challenge"}}'
         )
         {


### PR DESCRIPTION
## Summary

- use the `pwnshop` command provided by the Nix dev shell instead of a removed root `./pwnshop` path
- fail early if the publish build step produces no challenge image IDs

## Root cause

PR #243 moved publish to consume the freshly built image IDs, but the workflow invoked `./pwnshop build`. Current `main` packages `pwnshop` into the Nix dev shell and no longer has a root `./pwnshop` script.

## Validation

- resolved the conflict against current `main`
- `git diff --check`