### PR TITLE
ci: simplify challenge image publishing

### DIFF
--- a/.github/workflows/publish-challenges.yml
+++ b/.github/workflows/publish-challenges.yml
@@ -51,10 +51,6 @@ jobs:
       run: |
         challenge_images="$RUNNER_TEMP/challenge-images.txt"
         pwnshop build "$CHALLENGES_DIR" | tee "$challenge_images"
-        if [ ! -s "$challenge_images" ]; then
-          echo "::error::No challenge images were built"
-          exit 1
-        fi
         echo "challenge_images=$challenge_images" >> "$GITHUB_OUTPUT"
 
     - name: Test challenges


### PR DESCRIPTION
## Summary

- remove the extra empty-image-file guard from the publish build step
- keep the `pwnshop build | tee` flow unchanged

## Rationale

The guard is redundant defensive code: `pwnshop build` already fails when it cannot find or build challenge targets, and the publish workflow is only entered when modified challenges exist. Keeping the shell step direct makes the workflow easier to read.

## Validation

- `git diff --check`