### PR TITLE
Address challenge feedback from Discord

### DIFF
--- a/challenges/computing-101/building-a-web-server/common/run.py
+++ b/challenges/computing-101/building-a-web-server/common/run.py
@@ -26,19 +26,19 @@ config = (pathlib.Path(__file__).parent / ".config").read_text()
 level = int(config)
 
 strace_expected_parent = r"""
-1..10   execve(<execve_args>) = 0
-2..10   socket(AF_INET, SOCK_STREAM, IPPROTO_IP) = 3
-3..10   bind(3, {sa_family=AF_INET, sin_port=htons(<bind_port>), sin_addr=inet_addr("<bind_address>")}, 16) = 0
-4..10   listen(3, 0) = 0
-5..10   accept(3, NULL, NULL) = 4
+1..11   execve(<execve_args>) = 0
+2..11   socket(AF_INET, SOCK_STREAM, IPPROTO_IP) = 3
+3..11   bind(3, {sa_family=AF_INET, sin_port=htons(<bind_port>), sin_addr=inet_addr("<bind_address>")}, 16) = 0
+4..11   listen(3, 0) = 0
+5..11   accept(3, NULL, NULL) = 4
 6..8    read(4, <read_request>, <read_request_count>) = <read_request_result>
 7..8    open("<open_path>", O_RDONLY) = 5
 7..8    read(5, <read_file>, <read_file_count>) = <read_file_result>
 7..8    close(5) = 0
 6..8    write(4, "HTTP/1.0 200 OK\r\n\r\n", 19) = 19
 7..8    write(4, <write_file>, <write_file_count>) = <write_file_result>
-9..10   fork() = <fork_result>
-6..10   close(4) = 0
+9..11   fork() = <fork_result>
+6..11   close(4) = 0
 8..10   accept(3, NULL, NULL) = ?
 1..7    exit(0) = ?
 """
@@ -226,7 +226,7 @@ def create_secret_dir():
     return secret_dir
 
 
-def validate_strace(level, results, requirements):
+def validate_strace(level, results, requirements, *, print_child_traces=False):
     stdout = results["stdout"].decode("latin")
     stderr = results["stderr"].decode("latin")
 
@@ -301,8 +301,14 @@ def validate_strace(level, results, requirements):
     parent_captured, parent_errors = strace_validate("Parent Process", strace_expected_parent, parent_result, requirements)
     errors.extend(parent_errors)
 
-    child_pid = int(parent_captured.get("fork_result", 0))
-    if child_pid:
+    if print_child_traces:
+        child_index = 0
+        for child_pid, child_result in sorted(results["log"].items()):
+            if child_pid == parent_pid:
+                continue
+            strace_validate(f"Child Process {child_index}", "", child_result, requirements)
+            child_index += 1
+    elif level <= 10 and (child_pid := int(parent_captured.get("fork_result", 0))):
         child_result = results["log"][child_pid]
         child_captured, child_errors = strace_validate("Child Process", strace_expected_child, child_result, requirements)
         errors.extend(child_errors)
@@ -315,6 +321,15 @@ def retry_session():
     retries = requests.adapters.Retry(total=4, backoff_factor=0.1)
     session.mount("http://", requests.adapters.HTTPAdapter(max_retries=retries))
     return session
+
+
+def connection_error(method, exception):
+    message = str(exception)
+    if errno := re.search(r"\[Errno \d+\] [^')]+", message):
+        message = errno.group(0)
+    elif len(message) > 240:
+        message = f"{message[:237]}..."
+    return f"{method}: Failed to connect ({type(exception).__name__}: {message})"
 
 
 def random_data():
@@ -347,8 +362,8 @@ def validate_get(data=None):
         f.flush()
         try:
             response = session.get("http://localhost" + f.name, timeout=1)
-        except requests.exceptions.ConnectionError:
-            return "GET: Failed to connect"
+        except requests.exceptions.ConnectionError as e:
+            return connection_error("GET", e)
         if response.text.encode() != data:
             return "GET: File contents not correct"
 
@@ -361,8 +376,8 @@ def validate_post(data=None):
         pass
     try:
         session.post("http://localhost" + f.name, data=data, timeout=1)
-    except requests.exceptions.ConnectionError:
-        return "POST: Failed to connect"
+    except requests.exceptions.ConnectionError as e:
+        return connection_error("POST", e)
     try:
         if open(f.name, "rb").read() != data:
             return "POST: File contents not correct"
@@ -471,7 +486,8 @@ $ {sys.argv[0]} ./server
                     errors.append(f"Exception: {str(e)}")
         print()
 
-        strace_errors = validate_strace(level, results, requirements)
+        strace_errors = validate_strace(level, results, requirements,
+                                        print_child_traces=level == 11 and bool(errors))
         errors.extend(strace_errors)
 
         print("===== Result =====")

--- a/challenges/computing-101/building-a-web-server/web-server/DESCRIPTION.md
+++ b/challenges/computing-101/building-a-web-server/web-server/DESCRIPTION.md
@@ -1,5 +1,5 @@
-In the final challenge, your server must seamlessly support both GET and POST requests within a single program.
-After reading the incoming request using [read](https://man7.org/linux/man-pages/man2/read.2.html), your server will inspect the first few characters to determine whether it is dealing with a GET or a POST.
-Depending on the request type, it will process the data accordingly and then send back an appropriate response using [write](https://man7.org/linux/man-pages/man2/write.2.html).
-Throughout this process, [fork](https://man7.org/linux/man-pages/man2/fork.2.html) is employed to handle each connection concurrently, ensuring that your server can manage multiple requests at the same time.
-After completing this, you will have built a simple, but fully functional, web server capable of handling different types of HTTP requests.
+In the final challenge, your server must support both concurrent GET and concurrent POST requests within a single program.
+The checker will send a randomized mix of the two request types, so each accepted connection must fork a child that handles whichever request arrived.
+For a GET request, return the requested file contents as in the previous GET levels.
+For a POST request, write the request body to the requested path and return `200 OK` as in the previous POST level.
+After completing this, you will have built a simple, but fully functional, web server capable of handling both request types.

--- a/challenges/linux-luminarium/variables/command-substitution/challenge/.bashrc
+++ b/challenges/linux-luminarium/variables/command-substitution/challenge/.bashrc
@@ -3,9 +3,12 @@ function check_cmd {
 	then
 		rm -f /tmp/subshell
 
-		if [[ "${BASH_COMMAND}" =~ ^[a-zA-Z0-9_]*=\$(.*)$ ]] || [[ "${BASH_COMMAND}" =~ ^[a-zA-Z0-9_]*=\`.*\`$ ]]
+		if [[ "${BASH_COMMAND}" =~ ^(export[[:space:]]+)?([a-zA-Z_][a-zA-Z0-9_]*)=\$\(.*\)$ ]] ||
+		   [[ "${BASH_COMMAND}" =~ ^(export[[:space:]]+)?([a-zA-Z_][a-zA-Z0-9_]*)=\"\$\(.*\)\"$ ]] ||
+		   [[ "${BASH_COMMAND}" =~ ^(export[[:space:]]+)?([a-zA-Z_][a-zA-Z0-9_]*)=\`.*\`$ ]] ||
+		   [[ "${BASH_COMMAND}" =~ ^(export[[:space:]]+)?([a-zA-Z_][a-zA-Z0-9_]*)=\"\`.*\`\"$ ]]
 		then
-			echo ${BASH_COMMAND%%=*} > /tmp/dstvar
+			echo "${BASH_REMATCH[2]}" > /tmp/dstvar
 		else
 			rm -f /tmp/dstvar
 		fi


### PR DESCRIPTION
THIS MESSAGE IS GENERATED BY AN AUTOMATED PROCESS.

## Summary
- Addressed feedback from sanitized public Discord messages.
- `challenges/linux-luminarium/variables/command-substitution/challenge/.bashrc` now accepts valid Bash forms such as `export PWN=$(/challenge/run)` in addition to `PWN=$(/challenge/run)`.
- `challenges/linux-luminarium/variables/command-substitution/tests_private/test_solve.py` now covers direct assignment, exported assignment, quoted command substitution, and wrong-variable redaction.
- `challenges/computing-101/building-a-web-server/common/run.py` now gives the final web-server level better failure diagnostics for GET/POST connection failures and prints child traces on request failures.
- `challenges/computing-101/building-a-web-server/web-server/DESCRIPTION.md` now states that the checker sends a randomized mix of concurrent GET and POST requests.

## Validation
- `bash -n challenges/linux-luminarium/variables/command-substitution/challenge/.bashrc`
- `python3 -m py_compile challenges/linux-luminarium/variables/command-substitution/tests_private/test_solve.py`
- Python syntax compile of rendered `challenges/computing-101/building-a-web-server/common/run.py` after stripping Jinja raw markers.
- Bash marker probe confirmed both `PWN=$(...)` and `export PWN=$(...)` record `dst=PWN`.
- `nix develop --command pwnshop test challenges/computing-101/introspecting/gdb-run-stdin`
- `nix develop --command pwnshop test challenges/linux-luminarium/variables/command-substitution`
- `nix develop --command pwnshop test challenges/computing-101/building-a-web-server/web-server`
- `nix develop --command pwnshop run --timeout 60 challenges/computing-101/building-a-web-server/web-server /challenge/run /bin/true` confirmed failure output includes concise connection details.
- The saved `pwnshop-test-attempt-5.log` reports all tests passed: 12 challenges, 12 testcases.
- UX review found the recorded command-substitution and web-server flows consistent with the updated text and runtime behavior.

## Notes / deferred follow-ups
- Commit-time blocker: this host lacks `/usr/bin/git-crypt`, so before committing, stage the edited `tests_private` file in an environment with `git-crypt` available and run `tools/git-hooks/pre-commit`.
