### PR TITLE
Address challenge feedback from Discord

### DIFF
--- a/challenges/computing-101/building-a-web-server/DESCRIPTION.md
+++ b/challenges/computing-101/building-a-web-server/DESCRIPTION.md
@@ -1,5 +1,6 @@
 Now that you know how to write and debug assembly, it is time to do something real!
 In this module, you will develop the skills needed to build a web server from scratch, starting with a simple program and progressing to handling multiple HTTP GET and POST requests.
+Submit each level by passing your assembled and linked executable to `/challenge/run ./server`.
 Good luck!
 
 ----

--- a/challenges/computing-101/introspecting/gdb-disassemble/DESCRIPTION.md
+++ b/challenges/computing-101/introspecting/gdb-disassemble/DESCRIPTION.md
@@ -16,3 +16,8 @@ End of assembler dump.
 ```
 
 Read the output to find the secret number, then submit it with `/challenge/submit-number`.
+
+----
+**NOTE:**
+If GDB says `No debugging symbols found`, it means that optional debugging information is absent, not that GDB cannot debug the program.
+You can still use `starti` and `disassemble` to inspect its instructions.

--- a/challenges/computing-101/introspecting/gdb-disassemble/challenge/.gdb
+++ b/challenges/computing-101/introspecting/gdb-disassemble/challenge/.gdb
@@ -1,14 +1,14 @@
 set disassembly-flavor intel
 set logging redirect on
 set logging file /dev/null
-set logging on
+set logging enabled on
 set confirm off
 set height 0
 
 define hook-stop
   if !$hook_ran
     set $hook_ran = 1
-    set logging off
+    set logging enabled off
     printf "\n\n"
     printf "HACKER: You successfully started your program!\n"
     printf "HACKER: Now, run the 'disassemble' command to view the assembly code.\n"

--- a/challenges/computing-101/the-stack-revisited/build-frame/challenge/.py/chal.py
+++ b/challenges/computing-101/the-stack-revisited/build-frame/challenge/.py/chal.py
@@ -81,7 +81,9 @@ def check_runtime(so_path):
         want = len(set(data))
         assert got == want, (
             f"solve() on {len(data)} bytes should be {want} distinct, "
-            f"but your solve returned {as_signed(got)}." + diagnose(data, got)
+            f"but your solve returned {as_signed(got)}.{diagnose(data, got)}\n"
+            f"Input bytes (hex): {data.hex()}\n"
+            f"Reproduce with: /challenge/harness /tmp/your-program.so {data.hex()}"
         )
         suffix = "" if len(data) == 1 else "s"
         print(f"  ok: {len(data)} byte{suffix} -> {got} distinct")

--- a/challenges/linux-luminarium/common/Dockerfile.j2
+++ b/challenges/linux-luminarium/common/Dockerfile.j2
@@ -6,6 +6,7 @@ RUN apt-get update && apt-get install --no-install-recommends -yqq \
     bash-builtins \
     build-essential \
     john \
+    kitty-terminfo \
     man-db \
     manpages \
     python3-asteval \

--- a/challenges/linux-luminarium/destruction/forkbomb/challenge.yml
+++ b/challenges/linux-luminarium/destruction/forkbomb/challenge.yml
@@ -1,0 +1,1 @@
+privileged: true

--- a/challenges/linux-luminarium/piping/redir-then-grep/DESCRIPTION.md
+++ b/challenges/linux-luminarium/piping/redir-then-grep/DESCRIPTION.md
@@ -6,3 +6,5 @@ In preparation for more complex levels, we want you to:
 1. Redirect the output of `/challenge/run` to `/tmp/data.txt`.
 2. This will result in a hundred thousand lines of text, with one of them being the flag, in `/tmp/data.txt`.
 3. `grep` that for the flag!
+
+Remember, the flags you've seen in prior levels start with `pwn.college{`, so search for that prefix rather than the English word `flag`.

--- a/challenges/linux-luminarium/terminal-multiplexing/switch-windows-tmux/challenge/.make_tmux
+++ b/challenges/linux-luminarium/terminal-multiplexing/switch-windows-tmux/challenge/.make_tmux
@@ -1,17 +1,18 @@
 #!/bin/bash
+set -euo pipefail
 
 SESSION_NAME="challenge_session"
-tmux new-session -d -s "$SESSION_NAME" bash
+tmux -f /dev/null new-session -d -s "$SESSION_NAME" bash
 sleep 1
 
-tmux send-keys -t "$SESSION_NAME:0" " cat <<MSG
+tmux send-keys -t "$SESSION_NAME:0" " clear; cat <<MSG
 Excellent work! You found window 0!
 Here is your flag: $1
 MSG" Enter
 
 tmux new-window -t "$SESSION_NAME"
 
-tmux send-keys -t "$SESSION_NAME:1" " cat <<MSG
+tmux send-keys -t "$SESSION_NAME:1" " clear; cat <<MSG
 Welcome to the tmux window switching challenge!
 You are currently in window 1.
 The flag is hidden in window 0.

--- a/challenges/linux-luminarium/terminal-multiplexing/switch-windows/DESCRIPTION.md
+++ b/challenges/linux-luminarium/terminal-multiplexing/switch-windows/DESCRIPTION.md
@@ -17,5 +17,5 @@ For this challenge, we've set up a screen session with two windows:
 - Window 0 has... well, you'll have to switch there to find out!
 - Window 1 has a welcome message
 
-Attach to the session with `screen -r`, then use one of the key combinations above to switch to Window 1.
+Attach to the session with `screen -r`, then use one of the key combinations above to switch to Window 0.
 Go get that flag!

--- a/challenges/linux-luminarium/terminal-multiplexing/switch-windows/challenge/.make_screens
+++ b/challenges/linux-luminarium/terminal-multiplexing/switch-windows/challenge/.make_screens
@@ -1,9 +1,9 @@
 #!/bin/bash
 
 SESSION_NAME="challenge_session"
-screen -dmS "$SESSION_NAME" bash
+screen -c /dev/null -dmS "$SESSION_NAME" bash
 sleep 1
 
-screen -S "$SESSION_NAME" -X screen                                                                                                     
-screen -S "$SESSION_NAME" -p 0 -X stuff " cat <<MSG\nExcellent work! You found window 0!\nHere is your flag: $1\nMSG\n"
-screen -S "$SESSION_NAME" -p 1 -X stuff " cat <<MSG\nWelcome to the window switching challenge!\nYou are currently in window 1.\nThe flag is hidden in window 0.\nUse Ctrl-A 0 to switch to window 0!\nMSG\n"
+screen -S "$SESSION_NAME" -X screen
+screen -S "$SESSION_NAME" -p 0 -X stuff " clear; cat <<MSG\nExcellent work! You found window 0!\nHere is your flag: $1\nMSG\n"
+screen -S "$SESSION_NAME" -p 1 -X stuff " clear; cat <<MSG\nWelcome to the window switching challenge!\nYou are currently in window 1.\nThe flag is hidden in window 0.\nUse Ctrl-A 0 to switch to window 0!\nMSG\n"

--- a/challenges/linux-luminarium/variables/command-substitution/challenge/.bashrc
+++ b/challenges/linux-luminarium/variables/command-substitution/challenge/.bashrc
@@ -1,11 +1,13 @@
 function check_cmd {
+	local assignment_re='^(export[[:space:]]+)?([a-zA-Z_][a-zA-Z0-9_]*)=(\$\((.*)\)|`(.*)`|"\$\((.*)\)"|"`(.*)`")$'
+
 	if [ "$BASH_SUBSHELL" -eq 0 ]
 	then
 		rm -f /tmp/subshell
 
-		if [[ "${BASH_COMMAND}" =~ ^[a-zA-Z0-9_]*=\$(.*)$ ]] || [[ "${BASH_COMMAND}" =~ ^[a-zA-Z0-9_]*=\`.*\`$ ]]
+		if [[ "${BASH_COMMAND}" =~ $assignment_re ]]
 		then
-			echo ${BASH_COMMAND%%=*} > /tmp/dstvar
+			printf '%s\n' "${BASH_REMATCH[2]}" > /tmp/dstvar
 		else
 			rm -f /tmp/dstvar
 		fi


### PR DESCRIPTION
THIS MESSAGE IS GENERATED BY AN AUTOMATED PROCESS.

## Summary
- Addresses learner friction identified from sanitized public Discord messages in `linux-luminarium` and `computing-101`.
- Adds `challenges/linux-luminarium/destruction/forkbomb/challenge.yml` so Fork Bomb uses the isolated Kata runtime. Updates `common/Dockerfile.j2`, `.make_screens`, `.make_tmux`, and `switch-windows/DESCRIPTION.md` to support `TERM=xterm-kitty`, ignore persistent Screen/tmux configuration, hide setup scaffolding, and direct learners to Window 0.
- Updates `variables/command-substitution/challenge/.bashrc` to accept quoted or unquoted `$()` and backtick substitutions, with or without `export`, while rejecting literal assignments and wrong destination variables. `piping/redir-then-grep/DESCRIPTION.md` now identifies the recognizable flag prefix.
- Updates `computing-101/introspecting/gdb-disassemble/{DESCRIPTION.md,challenge/.gdb}` to explain missing debug symbols and remove a GDB logging deprecation warning. `building-a-web-server/DESCRIPTION.md` documents `/challenge/run ./server`, and Build Frame’s `chal.py` prints failing input bytes with a copyable reproducer.

## Validation
- Under `nix develop`, targeted tests passed for all six Terminal Multiplexing tests, Command Substitution, Grepping Stored Results, GDB Disassemble, the first Building a Web Server executable level, and Build Frame.
- The supplied aggregate `pwnshop` log reports 130 challenges and 132 testcases passing.
- Playtests covered `TERM=xterm-kitty`, hostile Screen/tmux configuration, documented keyboard shortcuts, supported command-substitution forms and rejection cases, the GDB missing-symbol flow, and Build Frame’s reproducer.
- Shell, Python, and YAML syntax checks and `git diff --check` passed.

## Notes / deferred follow-ups
- Fork Bomb selected Kata and cleaned up safely, but its real solve did not reach the flag within either 60 or 120 seconds. No Fork Bomb solve pass is claimed; bounded learner completion remains unverified.
- Getting Started has no active source tree in this repository. Changes to `welcome/practice`, `welcome/sensai`, `welcome/ssh`, and `welcome/desktop-paste` are blocked on updating the separate `pwncollege/welcome-dojo` repository and browser-testing privileged-mode transitions, Windows SSH variants, and both clipboard directions.
- Further Debugging Refresher migration is blocked by curriculum order: `modifying-execution` uses a function call before ordinary calls are taught, while `broken-functions` combines calls, fault repair, and privilege behavior. A maintainer must choose between reordering function instruction and redesigning those exercises.
