### PR TITLE
ci: support per-dojo update targets

### DIFF
--- a/.github/workflows/publish-challenges.yml
+++ b/.github/workflows/publish-challenges.yml
@@ -121,7 +121,7 @@ jobs:
         echo "::endgroup::"
 
     - name: Update dojo
-      if: ${{ vars.DOJO_URL != '' && hashFiles(format('challenges/{0}/dojo.yml', matrix.challenges)) != '' }}
+      if: ${{ hashFiles(format('challenges/{0}/dojo.yml', matrix.challenges)) != '' }}
       shell: 'nix shell nixpkgs#uv --command bash --noprofile --norc -euo pipefail {0}'
       env:
         CHALLENGES_DIR: challenges/${{ matrix.challenges }}

--- a/tools/dojo/parse-dojo-yml
+++ b/tools/dojo/parse-dojo-yml
@@ -49,7 +49,9 @@ class RawDojoYml(BaseModel):
     id: str = Field(pattern=r"^[a-z0-9-]{1,32}$")
 
     name: Optional[str] = None
+    url: Optional[str] = None
     type: Optional[str] = None
+    password: Optional[str] = Field(default=None, pattern=r"^[\S ]{8,128}$")
     award: Optional[dict] = None
     description: Optional[str] = None
     visibility: Optional[Visibility] = None
@@ -147,6 +149,7 @@ class DojoSpec(BaseModel):
     name: str
 
     type: Optional[str] = None
+    password: Optional[str] = Field(default=None, pattern=r"^[\S ]{8,128}$")
     award: Optional[dict] = None
     description: Optional[str] = None
     visibility: Optional[Visibility] = None
@@ -325,6 +328,7 @@ def main() -> int:
             "id": raw_dojo.id,
             "name": dojo_name,
             "type": raw_dojo.type,
+            "password": raw_dojo.password,
             "award": raw_dojo.award,
             "description": raw_dojo.description or dojo_description_md,
             "visibility": raw_dojo.visibility.model_dump(exclude_none=True) if raw_dojo.visibility else None,
@@ -339,6 +343,8 @@ def main() -> int:
             return print_validation_errors("", error)
 
         spec = validated.model_dump(mode="json", exclude_none=True)
+        if raw_dojo.url is not None:
+            spec["url"] = raw_dojo.url
 
     except Exception as error:
         print(f"Error: failed to parse {dojo_yml}: {error}", file=sys.stderr)

--- a/tools/dojo/update-dojo
+++ b/tools/dojo/update-dojo
@@ -2,7 +2,6 @@
 # /// script
 # requires-python = ">=3.9"
 # dependencies = [
-#   "pyyaml>=6.0",
 #   "requests>=2.0",
 # ]
 # ///
@@ -13,6 +12,7 @@ import os
 import pathlib
 import subprocess
 import sys
+import urllib.parse
 
 import requests
 
@@ -25,12 +25,6 @@ def main() -> int:
 
     dojo_url = os.environ.get("DOJO_URL")
     dojo_token = os.environ.get("DOJO_TOKEN")
-    if not dojo_url:
-        print("Error: missing DOJO_URL env var.", file=sys.stderr)
-        return 2
-    if not dojo_token:
-        print("Error: missing DOJO_TOKEN env var.", file=sys.stderr)
-        return 2
 
     dojo_yml = args.dojo_yml
     dojo_prefix = "/".join(dojo_yml.parts[1:-1])
@@ -50,6 +44,23 @@ def main() -> int:
         return 0
 
     spec = json.loads(parse_result.stdout)
+    dojo_yml_url = spec.pop("url", None)
+    dojo_url_id = None
+    if dojo_yml_url:
+        parsed_url = urllib.parse.urlparse(dojo_yml_url)
+        path_parts = [part for part in parsed_url.path.split("/") if part]
+        if not parsed_url.scheme or not parsed_url.netloc or not path_parts:
+            print(f"Error: invalid dojo url in {dojo_yml}: {dojo_yml_url}", file=sys.stderr)
+            return 1
+        dojo_url = f"{parsed_url.scheme}://{parsed_url.netloc}"
+        dojo_url_id = path_parts[1] if path_parts[0] == "dojo" and len(path_parts) > 1 else path_parts[0]
+
+    if not dojo_url:
+        print("Skipping: missing DOJO_URL env var and dojo.yml url.", file=sys.stderr)
+        return 0
+    if not dojo_token:
+        print("Error: missing DOJO_TOKEN env var.", file=sys.stderr)
+        return 2
 
     for module in spec.get("modules", []):
         module_id = module.get("id")
@@ -60,7 +71,7 @@ def main() -> int:
             slug = f"{dojo_prefix}/{module_id}/{challenge_id}"
             resource["image"] = f"{args.registry}/{slug}:latest"
 
-    dojo_id = spec["id"]
+    dojo_id = dojo_url_id or spec["id"]
     update_url = f"{dojo_url}/pwncollege_api/v1/dojos/{dojo_id}/update"
     try:
         response = requests.post(


### PR DESCRIPTION
This lets `dojo.yml` select its deployment target and carry private-dojo metadata while preserving the repository-wide `DOJO_URL` fallback for existing dojos.