### PR TITLE
runtime: mount nix store explicitly

### DIFF
--- a/tools/pwnshop/src/pwnshop/lib/__init__.py
+++ b/tools/pwnshop/src/pwnshop/lib/__init__.py
@@ -145,6 +145,7 @@ def run_challenge(
                 "--env=PWN_USER=hacker",
                 f"--env=PATH={container_path}",
                 "--volume=/nix:/nix:ro",
+                "--volume=/nix/store:/nix/store:ro",
                 *runtime_options,
                 *[f"--volume={volume}:{volume}:ro" for volume in (volumes or [])],
                 challenge_image,


### PR DESCRIPTION
This explicitly mounts the overlay-backed Nix store into Kata workspaces while preserving the parent `/nix` mount for profiles and other Nix state.