### PR TITLE
Stabilize Kata challenge lifecycle transitions

### DIFF
--- a/tools/pwnshop/src/pwnshop/lib/__init__.py
+++ b/tools/pwnshop/src/pwnshop/lib/__init__.py
@@ -10,6 +10,7 @@ import re
 import shutil
 import subprocess
 import tempfile
+import threading
 import time
 from typing import Iterable, Iterator, List, Optional, Sequence
 
@@ -21,6 +22,8 @@ import yaml
 logger = logging.getLogger(__name__)
 
 CHALLENGE_SEED = int(os.environ.get("CHALLENGE_SEED", "0"))
+
+_KATA_TRANSITION_LOCK = threading.Lock()
 
 clang_format = shutil.which("clang-format")
 if not clang_format:
@@ -100,6 +103,13 @@ def image_path(challenge_image: str) -> str:
     return ""
 
 
+def _run_with_transition_lock(runtime: str, function, *args, **kwargs):
+    if runtime != "kata":
+        return function(*args, **kwargs)
+    with _KATA_TRANSITION_LOCK:
+        return function(*args, **kwargs)
+
+
 @contextlib.contextmanager
 def run_challenge(
     challenge_path: pathlib.Path,
@@ -135,7 +145,9 @@ def run_challenge(
     )
     container = None
     try:
-        container = subprocess.check_output(
+        container = _run_with_transition_lock(
+            runtime,
+            subprocess.check_output,
             [
                 "docker",
                 "run",
@@ -203,7 +215,9 @@ def run_challenge(
     finally:
         if container:
             logger.debug("removing container %s", container[:12])
-            subprocess.run(
+            _run_with_transition_lock(
+                runtime,
+                subprocess.run,
                 ["docker", "rm", "--force", container],
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,

--- a/tools/pwnshop/tests/test_kata_transition.py
+++ b/tools/pwnshop/tests/test_kata_transition.py
@@ -1,0 +1,42 @@
+import pathlib
+import sys
+import threading
+import unittest
+
+
+PWNSHOP_ROOT = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(PWNSHOP_ROOT / "src"))
+
+from pwnshop import lib  # noqa: E402
+
+
+class KataTransitionTests(unittest.TestCase):
+    def test_kata_workers_are_serialized(self):
+        first_entered = threading.Event()
+        release_first = threading.Event()
+        second_entered = threading.Event()
+
+        def first_call():
+            first_entered.set()
+            release_first.wait()
+
+        first = threading.Thread(target=lib._run_with_transition_lock, args=("kata", first_call))
+        second = threading.Thread(
+            target=lib._run_with_transition_lock,
+            args=("kata", second_entered.set),
+        )
+        first.start()
+        self.assertTrue(first_entered.wait(1))
+        second.start()
+        self.assertFalse(second_entered.wait(0.1))
+        release_first.set()
+        first.join(1)
+        second.join(1)
+
+        self.assertFalse(first.is_alive())
+        self.assertFalse(second.is_alive())
+        self.assertTrue(second_entered.is_set())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

`pwnshop test` runs challenge workers in parallel. Privileged challenges use Kata, so several workers can call `docker run` or `docker rm --force` at the same time.

On this host, concurrent Kata starts occasionally fail before the testcase begins:

```text
failed to create shim task: Failed to Check if grpc server is working:
rpc error: code = DeadlineExceeded desc = timed out connecting to vsock ...:1024
```

The failure is intermittent. After the Kata 3.29.0 runtime update, an unlocked run passed 49 challenge executions before the next parallel matrix reproduced the timeout on `intercepting-communication/level-1`. Testcase `--attempts` cannot retry this because it happens while pwnshop is creating the container.

## Change

Serialize Kata `docker run` and `docker rm --force` calls with a process-local lock. The lock is held only for those Docker transitions: challenge builds, running VMs, testcase execution, and non-Kata containers remain concurrent.

There is no `/dev/kvm` ACL inspection, recovery polling, timeout, or runtime configuration change.

## Verification

All commands ran inside `nix develop`.

- The focused transition-lock unit test passes.
- Without the lock, five four-worker bursts passed 20 challenges and 40 testcases, followed by one 29-challenge matrix passing 58 testcases. The next identical matrix reproduced the vsock timeout during Kata container setup.
- With the lock restored, the same 29-challenge, four-worker matrix passed all 58 testcases with retries disabled.
- The failed setup left one partially-created challenge container; it was identified and removed after the test.
