### PR TITLE
Restore the legacy Dojo workspace marker

### DIFF
--- a/runtime/workspace/agent/cmd/workspace-entrypoint/main.go
+++ b/runtime/workspace/agent/cmd/workspace-entrypoint/main.go
@@ -26,6 +26,8 @@ const workspaceProfileBin = "/run/workspace/profile/bin"
 const workspaceProfileScript = "/run/workspace/profile/etc/profile.d/99-pwn-workspace.sh"
 const workspaceUserRunDir = "/run/workspace/user"
 const workspaceServicesDir = "/run/workspace/user/services"
+const legacyDojoWorkspaceDir = "/run/dojo/sys/workspace"
+const legacyDojoPrivilegedFile = "/run/dojo/sys/workspace/privileged"
 const systemProfileScript = "/etc/profile.d/99-pwn-workspace.sh"
 const userShell = "/run/workspace/profile/bin/bash"
 
@@ -141,6 +143,9 @@ func prepareWorkspace(config workspaceConfig) error {
 	if err := setupRunDirectories(); err != nil {
 		return err
 	}
+	if err := setupLegacyDojoWorkspace(); err != nil {
+		return err
+	}
 	if err := setupSystemEnvironment(); err != nil {
 		return err
 	}
@@ -180,6 +185,16 @@ func setupRunDirectories() error {
 		return err
 	}
 	return linkServiceDefinitions()
+}
+
+func setupLegacyDojoWorkspace() error {
+	if err := os.MkdirAll(legacyDojoWorkspaceDir, 0755); err != nil {
+		return err
+	}
+	if err := os.WriteFile(legacyDojoPrivilegedFile, []byte("0\n"), 0444); err != nil {
+		return err
+	}
+	return os.Chmod(legacyDojoPrivilegedFile, 0444)
 }
 
 func linkChallengeBin() error {


### PR DESCRIPTION
## Summary

- recreate /run/dojo/sys/workspace/privileged for local pwnshop workspaces
- expose the legacy standard-workspace value zero plus newline with mode 0444
- keep workspace practice mode separate from challenge privilege and runtime selection

## Why

Production Dojo provides this file through its read-only DojoFS mount. The local Nix workspace does not. Legacy Green /usr/local/bin/vm helpers read it on every non-root invocation and otherwise fail with FileNotFoundError. Restoring this ambient workspace contract centrally avoids changing any challenge.

## Verification

- targeted formatter check: clean
- workspace-agent packages build with go test ./...
- independent mainline workspace launch as uid 1000: value zero, mode 0444
- integration-stack real solves from kernel-security, speculative-execution, and system-exploitation: 3 challenges / 6 testcases


## CI prerequisite

The formatter-only fix in #271 is merged into main.