### PR TITLE
Linux - Chaining - Execution

### DIFF
--- a/challenges/linux-luminarium/chaining/execution/challenge/.bashrc
+++ b/challenges/linux-luminarium/chaining/execution/challenge/.bashrc
@@ -1,7 +1,9 @@
 function check_cmd {
 	BCMD=($BASH_COMMAND)
+	
 
 	[ "${#BCMD[@]}" -eq 1 ] || return 0
+	BCMD[0]="${BCMD[0]/#\~/$HOME}"
 	[ -f "${BCMD[0]}" ] || return 0
 	FILE=$(realpath ${BCMD[0]})
 	[[ "$FILE" == $HOME/* ]] || return 0

--- a/challenges/linux-luminarium/chaining/execution/challenge/.bashrc
+++ b/challenges/linux-luminarium/chaining/execution/challenge/.bashrc
@@ -1,6 +1,5 @@
 function check_cmd {
 	BCMD=($BASH_COMMAND)
-	
 
 	[ "${#BCMD[@]}" -eq 1 ] || return 0
 	BCMD[0]="${BCMD[0]/#\~/$HOME}"


### PR DESCRIPTION
modified .bashrc to accept ~/file as $HOME/file